### PR TITLE
feat: add boolean variants

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -104,12 +104,12 @@ describe("cva", () => {
           },
           {
             intent: "warning",
-            disabled: "false",
+            disabled: false,
             class: "button--warning-enabled text-gray-800",
           },
           {
             intent: "warning",
-            disabled: "true",
+            disabled: true,
             class: "button--warning-disabled text-black",
           },
         ],
@@ -167,12 +167,12 @@ describe("cva", () => {
           },
           {
             intent: "warning",
-            disabled: "false",
+            disabled: false,
             class: ["button--warning-enabled", "text-gray-800"],
           },
           {
             intent: "warning",
-            disabled: "true",
+            disabled: true,
             class: ["button--warning-disabled", "text-black"],
           },
         ],
@@ -196,10 +196,7 @@ describe("cva", () => {
         ],
 
         [{ size: "small" }, "button--small text-sm py-1 px-2"],
-        [
-          { disabled: "true" },
-          "button--disabled opacity-050 cursor-not-allowed",
-        ],
+        [{ disabled: true }, "button--disabled opacity-050 cursor-not-allowed"],
         [
           { intent: "secondary", size: null },
           "button--secondary bg-white text-gray-800 border-gray-400 hover:bg-gray-100",
@@ -217,7 +214,7 @@ describe("cva", () => {
           "button--warning bg-yellow-500 border-transparent hover:bg-yellow-600 button--large text-lg py-2.5 px-4",
         ],
         [
-          { intent: "warning", size: "large", disabled: "true" },
+          { intent: "warning", size: "large", disabled: true },
           "button--warning bg-yellow-500 border-transparent hover:bg-yellow-600 button--disabled opacity-050 cursor-not-allowed button--large text-lg py-2.5 px-4 button--warning-disabled text-black",
         ],
       ])("button(%o)", (options, expected) => {
@@ -264,17 +261,17 @@ describe("cva", () => {
             },
             {
               intent: "warning",
-              disabled: "false",
+              disabled: false,
               class: "button--warning-enabled text-gray-800",
             },
             {
               intent: "warning",
-              disabled: "true",
+              disabled: true,
               class: "button--warning-disabled text-black",
             },
           ],
           defaultVariants: {
-            disabled: "false",
+            disabled: false,
             intent: "primary",
             size: "medium",
           },
@@ -335,17 +332,17 @@ describe("cva", () => {
             },
             {
               intent: "warning",
-              disabled: "false",
+              disabled: false,
               class: ["button--warning-enabled", "text-gray-800"],
             },
             {
               intent: "warning",
-              disabled: "true",
+              disabled: true,
               class: ["button--warning-disabled", "text-black"],
             },
           ],
           defaultVariants: {
-            disabled: "false",
+            disabled: false,
             intent: "primary",
             size: "medium",
           },
@@ -380,7 +377,7 @@ describe("cva", () => {
           "button font-semibold border rounded button--primary bg-blue-500 text-white border-transparent hover:bg-blue-600 button--enabled cursor-pointer button--small text-sm py-1 px-2",
         ],
         [
-          { disabled: "true" },
+          { disabled: true },
           "button font-semibold border rounded button--primary bg-blue-500 text-white border-transparent hover:bg-blue-600 button--disabled opacity-050 cursor-not-allowed button--medium text-base py-2 px-4 button--primary-medium uppercase",
         ],
         [
@@ -400,7 +397,7 @@ describe("cva", () => {
           "button font-semibold border rounded button--warning bg-yellow-500 border-transparent hover:bg-yellow-600 button--enabled cursor-pointer button--large text-lg py-2.5 px-4 button--warning-enabled text-gray-800",
         ],
         [
-          { intent: "warning", size: "large", disabled: "true" },
+          { intent: "warning", size: "large", disabled: true },
           "button font-semibold border rounded button--warning bg-yellow-500 border-transparent hover:bg-yellow-600 button--disabled opacity-050 cursor-not-allowed button--large text-lg py-2.5 px-4 button--warning-disabled text-black",
         ],
       ])("button(%o)", (options, expected) => {
@@ -449,12 +446,12 @@ describe("cva", () => {
             },
             {
               intent: "warning",
-              disabled: "false",
+              disabled: false,
               class: "button--warning-enabled text-gray-800",
             },
             {
               intent: "warning",
-              disabled: "true",
+              disabled: true,
               class: "button--warning-disabled text-black",
             },
           ],
@@ -515,12 +512,12 @@ describe("cva", () => {
             },
             {
               intent: "warning",
-              disabled: "false",
+              disabled: false,
               class: ["button--warning-enabled", "text-gray-800"],
             },
             {
               intent: "warning",
-              disabled: "true",
+              disabled: true,
               class: ["button--warning-disabled", "text-black"],
             },
           ],
@@ -549,7 +546,7 @@ describe("cva", () => {
           "button font-semibold border rounded button--small text-sm py-1 px-2",
         ],
         [
-          { disabled: "true" },
+          { disabled: true },
           "button font-semibold border rounded button--disabled opacity-050 cursor-not-allowed",
         ],
         [
@@ -569,7 +566,7 @@ describe("cva", () => {
           "button font-semibold border rounded button--warning bg-yellow-500 border-transparent hover:bg-yellow-600 button--large text-lg py-2.5 px-4",
         ],
         [
-          { intent: "warning", size: "large", disabled: "true" },
+          { intent: "warning", size: "large", disabled: true },
           "button font-semibold border rounded button--warning bg-yellow-500 border-transparent hover:bg-yellow-600 button--disabled opacity-050 cursor-not-allowed button--large text-lg py-2.5 px-4 button--warning-disabled text-black",
         ],
       ])("button(%o)", (options, expected) => {
@@ -616,17 +613,17 @@ describe("cva", () => {
             },
             {
               intent: "warning",
-              disabled: "false",
+              disabled: false,
               class: "button--warning-enabled text-gray-800",
             },
             {
               intent: "warning",
-              disabled: "true",
+              disabled: true,
               class: "button--warning-disabled text-black",
             },
           ],
           defaultVariants: {
-            disabled: "false",
+            disabled: false,
             intent: "primary",
             size: "medium",
           },
@@ -687,17 +684,17 @@ describe("cva", () => {
             },
             {
               intent: "warning",
-              disabled: "false",
+              disabled: false,
               class: ["button--warning-enabled", "text-gray-800"],
             },
             {
               intent: "warning",
-              disabled: "true",
+              disabled: true,
               class: ["button--warning-disabled", "text-black"],
             },
           ],
           defaultVariants: {
-            disabled: "false",
+            disabled: false,
             intent: "primary",
             size: "medium",
           },
@@ -732,7 +729,7 @@ describe("cva", () => {
           "button font-semibold border rounded button--primary bg-blue-500 text-white border-transparent hover:bg-blue-600 button--enabled cursor-pointer button--small text-sm py-1 px-2",
         ],
         [
-          { disabled: "true" },
+          { disabled: true },
           "button font-semibold border rounded button--primary bg-blue-500 text-white border-transparent hover:bg-blue-600 button--disabled opacity-050 cursor-not-allowed button--medium text-base py-2 px-4 button--primary-medium uppercase",
         ],
         [
@@ -752,7 +749,7 @@ describe("cva", () => {
           "button font-semibold border rounded button--warning bg-yellow-500 border-transparent hover:bg-yellow-600 button--enabled cursor-pointer button--large text-lg py-2.5 px-4 button--warning-enabled text-gray-800",
         ],
         [
-          { intent: "warning", size: "large", disabled: "true" },
+          { intent: "warning", size: "large", disabled: true },
           "button font-semibold border rounded button--warning bg-yellow-500 border-transparent hover:bg-yellow-600 button--disabled opacity-050 cursor-not-allowed button--large text-lg py-2.5 px-4 button--warning-disabled text-black",
         ],
       ])("button(%o)", (options, expected) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,8 @@ export const cx = <T extends CxOptions>(...classes: T): CxReturn =>
 
 /* cva
   ============================================ */
+type Booleans = { true: true; false: false };
+type BoolMapping<T> = Booleans[T & keyof Booleans] | Exclude<T, keyof Booleans>;
 
 interface ClassProp {
   class?: ClassValue;
@@ -24,7 +26,7 @@ interface ClassProp {
 type VariantsSchema = Record<string, Record<string, ClassValue>>;
 
 type VariantsConfig<Variants extends VariantsSchema> = {
-  [Variant in keyof Variants]?: keyof Variants[Variant];
+  [Variant in keyof Variants]?: BoolMapping<keyof Variants[Variant]>;
 };
 
 export const cva =

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,8 +16,7 @@ export const cx = <T extends CxOptions>(...classes: T): CxReturn =>
 
 /* cva
   ============================================ */
-type Booleans = { true: true; false: false };
-type BoolMapping<T> = Booleans[T & keyof Booleans] | Exclude<T, keyof Booleans>;
+type BoolMapping<T> = T extends "true" ? true : T extends "false" ? false : T;
 
 interface ClassProp {
   class?: ClassValue;


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
This PR aims to solve [Issue #2](https://github.com/joe-bell/cva/issues/2)
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context
Currently, boolean variants aren't supported by the package.
With this PR, variants such as:
```js
const button = cva("button", {
  variants: {
    disabled: {
      false: "opacity-100",
      true: "opacity-050"
    }
  }
});
```
Could be used as native boolean variants: 
```js
button({ disabled: true })
```

Also, having both boolean & string variants work (as mentioned in the according to issue).

### Tasks:
- [X] Implement feature
- [X] Update tests

<!-- e.g. is there anything you'd like reviewers to focus on? -->
---

### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [X] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md).
- [X] Follow the [Style Guide](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md#style-guide).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).