### PR TITLE
Advise aliasing during install instead of TS Paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,19 +64,12 @@ Unfortunately, yes. Originally, the plan was the publish the package as `cva`, b
 
 In the meantime, you can always alias the package for your convenience…
 
-### Aliasing in TypeScript
+### Aliasing
 
-1. Add the alias to your [`tsconfig.json`](https://www.typescriptlang.org/tsconfig#paths) `paths`:
+1. Alias the package [`npm install`](https://docs.npmjs.com/cli/v6/commands/npm-install)
 
-   ```json
-   {
-     "compilerOptions": {
-       "baseUrl": ".",
-       "paths": {
-         "cva": ["node_modules/class-variance-authority"]
-       }
-     }
-   }
+   ```sh
+   npm i cva@npm:class-variance-authority
    ```
 
 2. Then import like so:


### PR DESCRIPTION
What's up 👋 

### Description

You can alias package names during installation, so it works even if you don't use TypeScript or you compile TypeScript with something that doesn't support TSConfig Paths.

It's supported since NPM 6.x (6.9 possibly?) and also in Yarn and PNPM (with way better docs).

- https://docs.npmjs.com/cli/v6/commands/npm-install
- https://classic.yarnpkg.com/lang/en/docs/cli/add/#toc-yarn-add-alias
- https://pnpm.io/aliases

Looks like this in package.json:

```json
  "dependencies": {
    "cva": "npm:class-variance-authority@^0.1.0"
  }
```

### Additional context

Awesome package BTW :)

---

### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md).
- [x] Follow the [Style Guide](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md#style-guide).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
