### PR TITLE
fix: allow both boolean states for boolean variant

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,7 @@
 type ClassValue = string | null | undefined | ClassValue[];
 
 type OmitUndefined<T> = T extends undefined ? never : T;
-type StringToBoolean<T> = T extends "true"
-  ? true
-  : T extends "false"
-  ? false
-  : T;
+type StringToBoolean<T> = T extends "true" | "false" ? boolean : T;
 
 export type VariantProps<Component extends (...args: any) => any> =
   OmitUndefined<Parameters<Component>[0]>;


### PR DESCRIPTION
### Description

Changes the typing of allowed values for boolean variants so that either boolean state is accepted, instead of just limiting it to the implemented values.

Fixes #21 

---

### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md).
- [x] Follow the [Style Guide](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md#style-guide).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
