### PR TITLE
Fix Behaviour of Falsey Boolean Variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,8 @@ const component = cva("base", options);
 1. `options` _(optional)_
    - `variants`: your variants schema
    - `compoundVariants`: variants based on a combination of previously defined variants
-   - `defaultVariants`: set default values for previously defined variants
+   - `defaultVariants`: set default values for previously defined variants.  
+     _note: these default values can be removed completely by setting the variant as `null`_
 
 #### Returns
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -546,6 +546,10 @@ describe("cva", () => {
           "button font-semibold border rounded button--small text-sm py-1 px-2",
         ],
         [
+          { disabled: false },
+          "button font-semibold border rounded button--enabled cursor-pointer",
+        ],
+        [
           { disabled: true },
           "button font-semibold border rounded button--disabled opacity-050 cursor-not-allowed",
         ],
@@ -566,8 +570,16 @@ describe("cva", () => {
           "button font-semibold border rounded button--warning bg-yellow-500 border-transparent hover:bg-yellow-600 button--large text-lg py-2.5 px-4",
         ],
         [
+          { intent: "warning", size: "large", disabled: null },
+          "button font-semibold border rounded button--warning bg-yellow-500 border-transparent hover:bg-yellow-600 button--large text-lg py-2.5 px-4",
+        ],
+        [
           { intent: "warning", size: "large", disabled: true },
           "button font-semibold border rounded button--warning bg-yellow-500 border-transparent hover:bg-yellow-600 button--disabled opacity-050 cursor-not-allowed button--large text-lg py-2.5 px-4 button--warning-disabled text-black",
+        ],
+        [
+          { intent: "warning", size: "large", disabled: false },
+          "button font-semibold border rounded button--warning bg-yellow-500 border-transparent hover:bg-yellow-600 button--enabled cursor-pointer button--large text-lg py-2.5 px-4 button--warning-enabled text-gray-800",
         ],
       ])("button(%o)", (options, expected) => {
         test(`returns ${expected}`, () => {
@@ -729,6 +741,14 @@ describe("cva", () => {
           "button font-semibold border rounded button--primary bg-blue-500 text-white border-transparent hover:bg-blue-600 button--enabled cursor-pointer button--small text-sm py-1 px-2",
         ],
         [
+          { disabled: null },
+          "button font-semibold border rounded button--primary bg-blue-500 text-white border-transparent hover:bg-blue-600 button--medium text-base py-2 px-4 button--primary-medium uppercase",
+        ],
+        [
+          { disabled: false },
+          "button font-semibold border rounded button--primary bg-blue-500 text-white border-transparent hover:bg-blue-600 button--enabled cursor-pointer button--medium text-base py-2 px-4 button--primary-medium uppercase",
+        ],
+        [
           { disabled: true },
           "button font-semibold border rounded button--primary bg-blue-500 text-white border-transparent hover:bg-blue-600 button--disabled opacity-050 cursor-not-allowed button--medium text-base py-2 px-4 button--primary-medium uppercase",
         ],
@@ -749,8 +769,16 @@ describe("cva", () => {
           "button font-semibold border rounded button--warning bg-yellow-500 border-transparent hover:bg-yellow-600 button--enabled cursor-pointer button--large text-lg py-2.5 px-4 button--warning-enabled text-gray-800",
         ],
         [
+          { intent: "warning", size: "large", disabled: null },
+          "button font-semibold border rounded button--warning bg-yellow-500 border-transparent hover:bg-yellow-600 button--large text-lg py-2.5 px-4",
+        ],
+        [
           { intent: "warning", size: "large", disabled: true },
           "button font-semibold border rounded button--warning bg-yellow-500 border-transparent hover:bg-yellow-600 button--disabled opacity-050 cursor-not-allowed button--large text-lg py-2.5 px-4 button--warning-disabled text-black",
+        ],
+        [
+          { intent: "warning", size: "large", disabled: false },
+          "button font-semibold border rounded button--warning bg-yellow-500 border-transparent hover:bg-yellow-600 button--enabled cursor-pointer button--large text-lg py-2.5 px-4 button--warning-enabled text-gray-800",
         ],
       ])("button(%o)", (options, expected) => {
         test(`returns ${expected}`, () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -382,7 +382,7 @@ describe("cva", () => {
         ],
         [
           { intent: "secondary", size: null },
-          "button font-semibold border rounded button--secondary bg-white text-gray-800 border-gray-400 hover:bg-gray-100 button--enabled cursor-pointer button--medium text-base py-2 px-4",
+          "button font-semibold border rounded button--secondary bg-white text-gray-800 border-gray-400 hover:bg-gray-100 button--enabled cursor-pointer",
         ],
         [
           { intent: "secondary", size: undefined },
@@ -754,7 +754,7 @@ describe("cva", () => {
         ],
         [
           { intent: "secondary", size: null },
-          "button font-semibold border rounded button--secondary bg-white text-gray-800 border-gray-400 hover:bg-gray-100 button--enabled cursor-pointer button--medium text-base py-2 px-4",
+          "button font-semibold border rounded button--secondary bg-white text-gray-800 border-gray-400 hover:bg-gray-100 button--enabled cursor-pointer",
         ],
         [
           { intent: "secondary", size: undefined },

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,9 @@ type StringToBoolean<T> = T extends "true" | "false" ? boolean : T;
 export type VariantProps<Component extends (...args: any) => any> =
   OmitUndefined<Parameters<Component>[0]>;
 
+const booleanToString = <T extends unknown>(value: T) =>
+  typeof value === "boolean" ? `${value}` : value;
+
 /* cx
   ============================================ */
 
@@ -53,11 +56,19 @@ export const cva =
     const { variants, defaultVariants } = config;
 
     const getVariantClassNames = Object.keys(variants).map(
-      (variant: keyof typeof variants) =>
-        variants[variant][
-          (props?.[variant as keyof typeof props] ||
-            defaultVariants?.[variant]) as keyof typeof variants[typeof variant]
-        ]
+      (variant: keyof typeof variants) => {
+        const variantProp = props?.[variant as keyof typeof props];
+        const defaultVariantProp = defaultVariants?.[variant];
+
+        if (variantProp === null) return null;
+
+        const variantKey = (booleanToString(variantProp) ||
+          booleanToString(
+            defaultVariantProp
+          )) as keyof typeof variants[typeof variant];
+
+        return variants[variant][variantKey];
+      }
     );
 
     const propsWithoutUndefined =


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Currently, `false` boolean variants don't work as expected. Somewhere `cva` is probably considering these variants `false` and ignoring them, rather than actually using them

Additionally, allow disabling of `defaultVariants` by passing an explicit `null`

- [x] Add tests to check for `false` boolean variants (and `null` values to disabled them)
- [x] Add the actual fix for this behaviour

### Additional context

Follow-up to #21 

---

### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md).
- [x] Follow the [Style Guide](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md#style-guide).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
