### PR TITLE
fix: export ClassProp type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ export const cx = <T extends CxOptions>(...classes: T): CxReturn =>
 /* cva
   ============================================ */
 
-interface ClassProp {
+export interface ClassProp {
   class?: ClassValue;
 }
 


### PR DESCRIPTION
### Description

Exports the `ClassProp` type since it is part of the public API of `cva`

I was expecting to have to export other types as well such as `VariantsConfig`, but I tried patching cva locally, only exporting `ClassProp`, and TypeScript seems happy with that 🤔 

Fixes #27 

### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md).
- [x] Follow the [Style Guide](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md#style-guide).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
