### PR TITLE
fix: variant key 0 case

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ export type VariantProps<Component extends (...args: any) => any> = Omit<
 >;
 
 const booleanToString = <T extends unknown>(value: T) =>
-  typeof value === "boolean" ? `${value}` : value;
+  typeof value === "boolean" ? `${value}` : value === 0 ? "0" : value;
 
 /* cx
   ============================================ */


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Variantkey is undefined when the variant key is 0, need to handle the special case of 0.
For example, NextUI grid component use `xs=0` to hide the component.
```
    xs: {
      true: 'xs:grow xs:max-w-full xs:basis-0',
    // this won't work, right now
      0: 'xs:grow-0 xs:hidden xs:max-w-0 xs:basis-0',
      1: 'xs:grow-0 xs:max-w-1/12 xs:basis-1/12'
    },
```

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md).
- [ ] Follow the [Style Guide](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md#style-guide).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
