### PR TITLE
Add Support for the `className` Prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,15 @@ const button = cva(["font-semibold", "border", "rounded"], {
       medium: ["text-base", "py-2", "px-4"],
     },
   },
-  compoundVariants: [{ intent: "primary", size: "medium", class: "uppercase" }],
+  compoundVariants: [
+    {
+      intent: "primary",
+      size: "medium",
+      class: "uppercase",
+      // **or** if you're a React.js user, `className` may feel more consistent:
+      // className: "uppercase"
+    },
+  ],
   defaultVariants: {
     intent: "primary",
     size: "medium",
@@ -151,7 +159,7 @@ button({ intent: "secondary", size: "small" });
 
 ### Additional Classes
 
-All `cva` components provide an optional `class` prop, which can be used to pass additional classes to the component.
+All `cva` components provide an optional `class` **or** `className` prop, which can be used to pass additional classes to the component.
 
 ```ts
 // components/button.ts
@@ -160,6 +168,9 @@ import { cva } from "class-variance-authority";
 const button = cva(/* … */);
 
 button({ class: "m-4" });
+// => "…buttonClasses m-4"
+
+button({ className: "m-4" });
 // => "…buttonClasses m-4"
 ```
 
@@ -510,7 +521,7 @@ const button = cva(base, {
     },
   },
   compoundVariants: [
-    { intent: "primary", size: "medium", class: primaryMedium },
+    { intent: "primary", size: "medium", className: primaryMedium },
   ],
   defaultVariants: {
     intent: "primary",
@@ -527,9 +538,7 @@ export const Button: React.FC<ButtonProps> = ({
   intent,
   size,
   ...props
-}) => (
-  <button className={button({ intent, size, class: className })} {...props} />
-);
+}) => <button className={button({ intent, size, className })} {...props} />;
 ```
 
 </details>
@@ -564,7 +573,9 @@ const button = cva("button", {
       medium: ["text-base", "py-2", "px-4"],
     },
   },
-  compoundVariants: [{ intent: "primary", size: "medium", class: "uppercase" }],
+  compoundVariants: [
+    { intent: "primary", size: "medium", className: "uppercase" },
+  ],
   defaultVariants: {
     intent: "primary",
     size: "medium",
@@ -580,9 +591,7 @@ export const Button: React.FC<ButtonProps> = ({
   intent,
   size,
   ...props
-}) => (
-  <button className={button({ intent, size, class: className })} {...props} />
-);
+}) => <button className={button({ intent, size, className })} {...props} />;
 ```
 
 </details>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "class-variance-authority",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "class-variance-authority",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "devDependencies": {
         "@swc/cli": "0.1.57",
         "@swc/core": "1.2.198",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -45,6 +45,18 @@ describe("cva", () => {
             aCheekyInvalidProp: "lol",
           })
         ).toBe("");
+        expect(example({ class: "adhoc-class" })).toBe("adhoc-class");
+        expect(example({ className: "adhoc-className" })).toBe(
+          "adhoc-className"
+        );
+        expect(
+          example({
+            // @ts-expect-error
+            class: "adhoc-class",
+            // @ts-expect-error
+            className: "adhoc-className",
+          })
+        ).toBe("adhoc-class adhoc-className");
       });
 
       test("undefined", () => {
@@ -56,6 +68,18 @@ describe("cva", () => {
             aCheekyInvalidProp: "lol",
           })
         ).toBe("");
+        expect(example({ class: "adhoc-class" })).toBe("adhoc-class");
+        expect(example({ className: "adhoc-className" })).toBe(
+          "adhoc-className"
+        );
+        expect(
+          example({
+            // @ts-expect-error
+            class: "adhoc-class",
+            // @ts-expect-error
+            className: "adhoc-className",
+          })
+        ).toBe("adhoc-class adhoc-className");
       });
 
       test("null", () => {
@@ -67,6 +91,18 @@ describe("cva", () => {
             aCheekyInvalidProp: "lol",
           })
         ).toBe("");
+        expect(example({ class: "adhoc-class" })).toBe("adhoc-class");
+        expect(example({ className: "adhoc-className" })).toBe(
+          "adhoc-className"
+        );
+        expect(
+          example({
+            // @ts-expect-error
+            class: "adhoc-class",
+            // @ts-expect-error
+            className: "adhoc-className",
+          })
+        ).toBe("adhoc-class adhoc-className");
       });
     });
 
@@ -112,6 +148,50 @@ describe("cva", () => {
             intent: "warning",
             disabled: true,
             class: "button--warning-disabled text-black",
+          },
+        ],
+      });
+      const buttonWithoutBaseWithoutDefaultsWithClassNameString = cva(null, {
+        variants: {
+          intent: {
+            primary:
+              "button--primary bg-blue-500 text-white border-transparent hover:bg-blue-600",
+            secondary:
+              "button--secondary bg-white text-gray-800 border-gray-400 hover:bg-gray-100",
+            warning:
+              "button--warning bg-yellow-500 border-transparent hover:bg-yellow-600",
+            danger:
+              "button--danger bg-red-500 text-white border-transparent hover:bg-red-600",
+          },
+          disabled: {
+            true: "button--disabled opacity-050 cursor-not-allowed",
+            false: "button--enabled cursor-pointer",
+          },
+          size: {
+            small: "button--small text-sm py-1 px-2",
+            medium: "button--medium text-base py-2 px-4",
+            large: "button--large text-lg py-2.5 px-4",
+          },
+          m: {
+            0: "m-0",
+            1: "m-1",
+          },
+        },
+        compoundVariants: [
+          {
+            intent: "primary",
+            size: "medium",
+            className: "button--primary-medium uppercase",
+          },
+          {
+            intent: "warning",
+            disabled: false,
+            className: "button--warning-enabled text-gray-800",
+          },
+          {
+            intent: "warning",
+            disabled: true,
+            className: "button--warning-disabled text-black",
           },
         ],
       });
@@ -179,10 +259,79 @@ describe("cva", () => {
           },
         ],
       });
+      const buttonWithoutBaseWithoutDefaultsWithClassNameArray = cva(null, {
+        variants: {
+          intent: {
+            primary: [
+              "button--primary",
+              "bg-blue-500",
+              "text-white",
+              "border-transparent",
+              "hover:bg-blue-600",
+            ],
+            secondary: [
+              "button--secondary",
+              "bg-white",
+              "text-gray-800",
+              "border-gray-400",
+              "hover:bg-gray-100",
+            ],
+            warning: [
+              "button--warning",
+              "bg-yellow-500",
+              "border-transparent",
+              "hover:bg-yellow-600",
+            ],
+            danger: [
+              "button--danger",
+              "bg-red-500",
+              "text-white",
+              "border-transparent",
+              "hover:bg-red-600",
+            ],
+          },
+          disabled: {
+            true: ["button--disabled", "opacity-050", "cursor-not-allowed"],
+            false: ["button--enabled", "cursor-pointer"],
+          },
+          size: {
+            small: ["button--small", "text-sm", "py-1", "px-2"],
+            medium: ["button--medium", "text-base", "py-2", "px-4"],
+            large: ["button--large", "text-lg", "py-2.5", "px-4"],
+          },
+          m: {
+            0: "m-0",
+            1: "m-1",
+          },
+        },
+        compoundVariants: [
+          {
+            intent: "primary",
+            size: "medium",
+            className: ["button--primary-medium", "uppercase"],
+          },
+          {
+            intent: "warning",
+            disabled: false,
+            className: ["button--warning-enabled", "text-gray-800"],
+          },
+          {
+            intent: "warning",
+            disabled: true,
+            className: ["button--warning-disabled", "text-black"],
+          },
+        ],
+      });
 
       type ButtonWithoutDefaultsWithoutBaseProps =
         | CVA.VariantProps<typeof buttonWithoutBaseWithoutDefaultsString>
-        | CVA.VariantProps<typeof buttonWithoutBaseWithoutDefaultsArray>;
+        | CVA.VariantProps<
+            typeof buttonWithoutBaseWithoutDefaultsWithClassNameString
+          >
+        | CVA.VariantProps<typeof buttonWithoutBaseWithoutDefaultsArray>
+        | CVA.VariantProps<
+            typeof buttonWithoutBaseWithoutDefaultsWithClassNameArray
+          >;
 
       describe.each<[ButtonWithoutDefaultsWithoutBaseProps, string]>([
         [
@@ -234,12 +383,36 @@ describe("cva", () => {
           { intent: "primary", m: 1 },
           "button--primary bg-blue-500 text-white border-transparent hover:bg-blue-600 m-1",
         ],
+        // !@TODO Add type "extractor" including class prop
+        [
+          {
+            intent: "primary",
+            m: 1,
+            class: "adhoc-class",
+          } as ButtonWithoutDefaultsWithoutBaseProps,
+          "button--primary bg-blue-500 text-white border-transparent hover:bg-blue-600 m-1 adhoc-class",
+        ],
+        [
+          {
+            intent: "primary",
+            m: 1,
+            className: "adhoc-classname",
+          } as ButtonWithoutDefaultsWithoutBaseProps,
+          "button--primary bg-blue-500 text-white border-transparent hover:bg-blue-600 m-1 adhoc-classname",
+        ],
+        // typings needed
       ])("button(%o)", (options, expected) => {
         test(`returns ${expected}`, () => {
           expect(buttonWithoutBaseWithoutDefaultsString(options)).toBe(
             expected
           );
+          expect(
+            buttonWithoutBaseWithoutDefaultsWithClassNameString(options)
+          ).toBe(expected);
           expect(buttonWithoutBaseWithoutDefaultsArray(options)).toBe(expected);
+          expect(
+            buttonWithoutBaseWithoutDefaultsWithClassNameArray(options)
+          ).toBe(expected);
         });
       });
     });
@@ -288,6 +461,59 @@ describe("cva", () => {
               intent: "warning",
               disabled: true,
               class: "button--warning-disabled text-black",
+            },
+          ],
+          defaultVariants: {
+            m: 0,
+            disabled: false,
+            intent: "primary",
+            size: "medium",
+          },
+        }
+      );
+      const buttonWithoutBaseWithDefaultsWithClassNameString = cva(
+        "button font-semibold border rounded",
+        {
+          variants: {
+            intent: {
+              primary:
+                "button--primary bg-blue-500 text-white border-transparent hover:bg-blue-600",
+              secondary:
+                "button--secondary bg-white text-gray-800 border-gray-400 hover:bg-gray-100",
+              warning:
+                "button--warning bg-yellow-500 border-transparent hover:bg-yellow-600",
+              danger:
+                "button--danger bg-red-500 text-white border-transparent hover:bg-red-600",
+            },
+            disabled: {
+              true: "button--disabled opacity-050 cursor-not-allowed",
+              false: "button--enabled cursor-pointer",
+            },
+            size: {
+              small: "button--small text-sm py-1 px-2",
+              medium: "button--medium text-base py-2 px-4",
+              large: "button--large text-lg py-2.5 px-4",
+            },
+            m: {
+              0: "m-0",
+              1: "m-1",
+            },
+          },
+          compoundVariants: [
+            {
+              intent: "primary",
+              size: "medium",
+              className: "button--primary-medium uppercase",
+            },
+            {
+              intent: "warning",
+              disabled: false,
+              className: "button--warning-enabled text-gray-800",
+            },
+            {
+              intent: "warning",
+              disabled: true,
+              className: "button--warning-disabled text-black",
             },
           ],
           defaultVariants: {
@@ -371,10 +597,88 @@ describe("cva", () => {
           },
         }
       );
+      const buttonWithoutBaseWithDefaultsWithClassNameArray = cva(
+        ["button", "font-semibold", "border", "rounded"],
+        {
+          variants: {
+            intent: {
+              primary: [
+                "button--primary",
+                "bg-blue-500",
+                "text-white",
+                "border-transparent",
+                "hover:bg-blue-600",
+              ],
+              secondary: [
+                "button--secondary",
+                "bg-white",
+                "text-gray-800",
+                "border-gray-400",
+                "hover:bg-gray-100",
+              ],
+              warning: [
+                "button--warning",
+                "bg-yellow-500",
+                "border-transparent",
+                "hover:bg-yellow-600",
+              ],
+              danger: [
+                "button--danger",
+                "bg-red-500",
+                "text-white",
+                "border-transparent",
+                "hover:bg-red-600",
+              ],
+            },
+            disabled: {
+              true: ["button--disabled", "opacity-050", "cursor-not-allowed"],
+              false: ["button--enabled", "cursor-pointer"],
+            },
+            size: {
+              small: ["button--small", "text-sm", "py-1", "px-2"],
+              medium: ["button--medium", "text-base", "py-2", "px-4"],
+              large: ["button--large", "text-lg", "py-2.5", "px-4"],
+            },
+            m: {
+              0: "m-0",
+              1: "m-1",
+            },
+          },
+          compoundVariants: [
+            {
+              intent: "primary",
+              size: "medium",
+              className: ["button--primary-medium", "uppercase"],
+            },
+            {
+              intent: "warning",
+              disabled: false,
+              className: ["button--warning-enabled", "text-gray-800"],
+            },
+            {
+              intent: "warning",
+              disabled: true,
+              className: ["button--warning-disabled", "text-black"],
+            },
+          ],
+          defaultVariants: {
+            m: 0,
+            disabled: false,
+            intent: "primary",
+            size: "medium",
+          },
+        }
+      );
 
       type ButtonWithoutBaseWithDefaultsProps =
         | CVA.VariantProps<typeof buttonWithoutBaseWithDefaultsString>
-        | CVA.VariantProps<typeof buttonWithoutBaseWithDefaultsArray>;
+        | CVA.VariantProps<
+            typeof buttonWithoutBaseWithDefaultsWithClassNameString
+          >
+        | CVA.VariantProps<typeof buttonWithoutBaseWithDefaultsArray>
+        | CVA.VariantProps<
+            typeof buttonWithoutBaseWithDefaultsWithClassNameArray
+          >;
 
       describe.each<[ButtonWithoutBaseWithDefaultsProps, string]>([
         [
@@ -436,10 +740,33 @@ describe("cva", () => {
           { intent: "primary", m: 1 },
           "button font-semibold border rounded button--primary bg-blue-500 text-white border-transparent hover:bg-blue-600 button--enabled cursor-pointer button--medium text-base py-2 px-4 m-1 button--primary-medium uppercase",
         ],
+        // !@TODO Add type "extractor" including class prop
+        [
+          {
+            intent: "primary",
+            m: 0,
+            class: "adhoc-class",
+          } as ButtonWithoutBaseWithDefaultsProps,
+          "button font-semibold border rounded button--primary bg-blue-500 text-white border-transparent hover:bg-blue-600 button--enabled cursor-pointer button--medium text-base py-2 px-4 m-0 button--primary-medium uppercase adhoc-class",
+        ],
+        [
+          {
+            intent: "primary",
+            m: 1,
+            className: "adhoc-classname",
+          } as ButtonWithoutBaseWithDefaultsProps,
+          "button font-semibold border rounded button--primary bg-blue-500 text-white border-transparent hover:bg-blue-600 button--enabled cursor-pointer button--medium text-base py-2 px-4 m-1 button--primary-medium uppercase adhoc-classname",
+        ],
       ])("button(%o)", (options, expected) => {
         test(`returns ${expected}`, () => {
           expect(buttonWithoutBaseWithDefaultsString(options)).toBe(expected);
+          expect(
+            buttonWithoutBaseWithDefaultsWithClassNameString(options)
+          ).toBe(expected);
           expect(buttonWithoutBaseWithDefaultsArray(options)).toBe(expected);
+          expect(buttonWithoutBaseWithDefaultsWithClassNameArray(options)).toBe(
+            expected
+          );
         });
       });
     });
@@ -486,6 +813,49 @@ describe("cva", () => {
               intent: "warning",
               disabled: true,
               class: "button--warning-disabled text-black",
+            },
+          ],
+        }
+      );
+      const buttonWithBaseWithoutDefaultsWithClassNameString = cva(
+        "button font-semibold border rounded",
+        {
+          variants: {
+            intent: {
+              primary:
+                "button--primary bg-blue-500 text-white border-transparent hover:bg-blue-600",
+              secondary:
+                "button--secondary bg-white text-gray-800 border-gray-400 hover:bg-gray-100",
+              warning:
+                "button--warning bg-yellow-500 border-transparent hover:bg-yellow-600",
+              danger:
+                "button--danger bg-red-500 text-white border-transparent hover:bg-red-600",
+            },
+            disabled: {
+              true: "button--disabled opacity-050 cursor-not-allowed",
+              false: "button--enabled cursor-pointer",
+            },
+            size: {
+              small: "button--small text-sm py-1 px-2",
+              medium: "button--medium text-base py-2 px-4",
+              large: "button--large text-lg py-2.5 px-4",
+            },
+          },
+          compoundVariants: [
+            {
+              intent: "primary",
+              size: "medium",
+              className: "button--primary-medium uppercase",
+            },
+            {
+              intent: "warning",
+              disabled: false,
+              className: "button--warning-enabled text-gray-800",
+            },
+            {
+              intent: "warning",
+              disabled: true,
+              className: "button--warning-disabled text-black",
             },
           ],
         }
@@ -553,10 +923,78 @@ describe("cva", () => {
           ],
         }
       );
+      const buttonWithBaseWithoutDefaultsWithClassNameArray = cva(
+        ["button", "font-semibold", "border", "rounded"],
+        {
+          variants: {
+            intent: {
+              primary: [
+                "button--primary",
+                "bg-blue-500",
+                "text-white",
+                "border-transparent",
+                "hover:bg-blue-600",
+              ],
+              secondary: [
+                "button--secondary",
+                "bg-white",
+                "text-gray-800",
+                "border-gray-400",
+                "hover:bg-gray-100",
+              ],
+              warning: [
+                "button--warning",
+                "bg-yellow-500",
+                "border-transparent",
+                "hover:bg-yellow-600",
+              ],
+              danger: [
+                "button--danger",
+                "bg-red-500",
+                "text-white",
+                "border-transparent",
+                "hover:bg-red-600",
+              ],
+            },
+            disabled: {
+              true: ["button--disabled", "opacity-050", "cursor-not-allowed"],
+              false: ["button--enabled", "cursor-pointer"],
+            },
+            size: {
+              small: ["button--small", "text-sm", "py-1", "px-2"],
+              medium: ["button--medium", "text-base", "py-2", "px-4"],
+              large: ["button--large", "text-lg", "py-2.5", "px-4"],
+            },
+          },
+          compoundVariants: [
+            {
+              intent: "primary",
+              size: "medium",
+              class: ["button--primary-medium", "uppercase"],
+            },
+            {
+              intent: "warning",
+              disabled: false,
+              class: ["button--warning-enabled", "text-gray-800"],
+            },
+            {
+              intent: "warning",
+              disabled: true,
+              class: ["button--warning-disabled", "text-black"],
+            },
+          ],
+        }
+      );
 
       type ButtonWithBaseWithoutDefaultsProps =
         | CVA.VariantProps<typeof buttonWithBaseWithoutDefaultsString>
-        | CVA.VariantProps<typeof buttonWithBaseWithoutDefaultsArray>;
+        | CVA.VariantProps<
+            typeof buttonWithBaseWithoutDefaultsWithClassNameString
+          >
+        | CVA.VariantProps<typeof buttonWithBaseWithoutDefaultsArray>
+        | CVA.VariantProps<
+            typeof buttonWithBaseWithoutDefaultsWithClassNameArray
+          >;
 
       describe.each<[ButtonWithBaseWithoutDefaultsProps, string]>([
         [
@@ -616,10 +1054,31 @@ describe("cva", () => {
           { intent: "warning", size: "large", disabled: false },
           "button font-semibold border rounded button--warning bg-yellow-500 border-transparent hover:bg-yellow-600 button--enabled cursor-pointer button--large text-lg py-2.5 px-4 button--warning-enabled text-gray-800",
         ],
+        // !@TODO Add type "extractor" including class prop
+        [
+          {
+            intent: "primary",
+            class: "adhoc-class",
+          } as ButtonWithBaseWithoutDefaultsProps,
+          "button font-semibold border rounded button--primary bg-blue-500 text-white border-transparent hover:bg-blue-600 adhoc-class",
+        ],
+        [
+          {
+            intent: "primary",
+            className: "adhoc-className",
+          } as ButtonWithBaseWithoutDefaultsProps,
+          "button font-semibold border rounded button--primary bg-blue-500 text-white border-transparent hover:bg-blue-600 adhoc-className",
+        ],
       ])("button(%o)", (options, expected) => {
         test(`returns ${expected}`, () => {
           expect(buttonWithBaseWithoutDefaultsString(options)).toBe(expected);
+          expect(
+            buttonWithBaseWithoutDefaultsWithClassNameString(options)
+          ).toBe(expected);
           expect(buttonWithBaseWithoutDefaultsArray(options)).toBe(expected);
+          expect(buttonWithBaseWithoutDefaultsWithClassNameArray(options)).toBe(
+            expected
+          );
         });
       });
     });
@@ -664,6 +1123,54 @@ describe("cva", () => {
               intent: "warning",
               disabled: true,
               class: "button--warning-disabled text-black",
+            },
+          ],
+          defaultVariants: {
+            disabled: false,
+            intent: "primary",
+            size: "medium",
+          },
+        }
+      );
+      const buttonWithBaseWithDefaultsWithClassNameString = cva(
+        "button font-semibold border rounded",
+        {
+          variants: {
+            intent: {
+              primary:
+                "button--primary bg-blue-500 text-white border-transparent hover:bg-blue-600",
+              secondary:
+                "button--secondary bg-white text-gray-800 border-gray-400 hover:bg-gray-100",
+              warning:
+                "button--warning bg-yellow-500 border-transparent hover:bg-yellow-600",
+              danger:
+                "button--danger bg-red-500 text-white border-transparent hover:bg-red-600",
+            },
+            disabled: {
+              true: "button--disabled opacity-050 cursor-not-allowed",
+              false: "button--enabled cursor-pointer",
+            },
+            size: {
+              small: "button--small text-sm py-1 px-2",
+              medium: "button--medium text-base py-2 px-4",
+              large: "button--large text-lg py-2.5 px-4",
+            },
+          },
+          compoundVariants: [
+            {
+              intent: "primary",
+              size: "medium",
+              className: "button--primary-medium uppercase",
+            },
+            {
+              intent: "warning",
+              disabled: false,
+              className: "button--warning-enabled text-gray-800",
+            },
+            {
+              intent: "warning",
+              disabled: true,
+              className: "button--warning-disabled text-black",
             },
           ],
           defaultVariants: {
@@ -741,10 +1248,79 @@ describe("cva", () => {
           },
         }
       );
+      const buttonWithBaseWithDefaultsWithClassNameArray = cva(
+        ["button", "font-semibold", "border", "rounded"],
+        {
+          variants: {
+            intent: {
+              primary: [
+                "button--primary",
+                "bg-blue-500",
+                "text-white",
+                "border-transparent",
+                "hover:bg-blue-600",
+              ],
+              secondary: [
+                "button--secondary",
+                "bg-white",
+                "text-gray-800",
+                "border-gray-400",
+                "hover:bg-gray-100",
+              ],
+              warning: [
+                "button--warning",
+                "bg-yellow-500",
+                "border-transparent",
+                "hover:bg-yellow-600",
+              ],
+              danger: [
+                "button--danger",
+                "bg-red-500",
+                "text-white",
+                "border-transparent",
+                "hover:bg-red-600",
+              ],
+            },
+            disabled: {
+              true: ["button--disabled", "opacity-050", "cursor-not-allowed"],
+              false: ["button--enabled", "cursor-pointer"],
+            },
+            size: {
+              small: ["button--small", "text-sm", "py-1", "px-2"],
+              medium: ["button--medium", "text-base", "py-2", "px-4"],
+              large: ["button--large", "text-lg", "py-2.5", "px-4"],
+            },
+          },
+          compoundVariants: [
+            {
+              intent: "primary",
+              size: "medium",
+              class: ["button--primary-medium", "uppercase"],
+            },
+            {
+              intent: "warning",
+              disabled: false,
+              class: ["button--warning-enabled", "text-gray-800"],
+            },
+            {
+              intent: "warning",
+              disabled: true,
+              class: ["button--warning-disabled", "text-black"],
+            },
+          ],
+          defaultVariants: {
+            disabled: false,
+            intent: "primary",
+            size: "medium",
+          },
+        }
+      );
 
       type ButtonWithBaseWithDefaultsProps =
         | CVA.VariantProps<typeof buttonWithBaseWithDefaultsString>
-        | CVA.VariantProps<typeof buttonWithBaseWithDefaultsArray>;
+        | CVA.VariantProps<typeof buttonWithBaseWithDefaultsWithClassNameString>
+        | CVA.VariantProps<typeof buttonWithBaseWithDefaultsArray>
+        | CVA.VariantProps<typeof buttonWithBaseWithDefaultsWithClassNameArray>;
 
       describe.each<[ButtonWithBaseWithDefaultsProps, string]>([
         [
@@ -815,10 +1391,31 @@ describe("cva", () => {
           { intent: "warning", size: "large", disabled: false },
           "button font-semibold border rounded button--warning bg-yellow-500 border-transparent hover:bg-yellow-600 button--enabled cursor-pointer button--large text-lg py-2.5 px-4 button--warning-enabled text-gray-800",
         ],
+        // !@TODO Add type "extractor" including class prop
+        [
+          {
+            intent: "primary",
+            class: "adhoc-class",
+          } as ButtonWithBaseWithDefaultsProps,
+          "button font-semibold border rounded button--primary bg-blue-500 text-white border-transparent hover:bg-blue-600 button--enabled cursor-pointer button--medium text-base py-2 px-4 button--primary-medium uppercase adhoc-class",
+        ],
+        [
+          {
+            intent: "primary",
+            className: "adhoc-classname",
+          } as ButtonWithBaseWithDefaultsProps,
+          "button font-semibold border rounded button--primary bg-blue-500 text-white border-transparent hover:bg-blue-600 button--enabled cursor-pointer button--medium text-base py-2 px-4 button--primary-medium uppercase adhoc-classname",
+        ],
       ])("button(%o)", (options, expected) => {
         test(`returns ${expected}`, () => {
           expect(buttonWithBaseWithDefaultsString(options)).toBe(expected);
+          expect(buttonWithBaseWithDefaultsWithClassNameString(options)).toBe(
+            expected
+          );
           expect(buttonWithBaseWithDefaultsArray(options)).toBe(expected);
+          expect(buttonWithBaseWithDefaultsWithClassNameArray(options)).toBe(
+            expected
+          );
         });
       });
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import type {
 
 export type VariantProps<Component extends (...args: any) => any> = Omit<
   OmitUndefined<Parameters<Component>[0]>,
-  "class"
+  "class" | "className"
 >;
 
 const falsyToString = <T extends unknown>(value: T) =>
@@ -49,9 +49,8 @@ type Props<T> = T extends ConfigSchema
 export const cva =
   <T>(base?: ClassValue, config?: Config<T>) =>
   (props?: Props<T>) => {
-    const className = props?.class;
-
-    if (config?.variants == null) return cx(base, className);
+    if (config?.variants == null)
+      return cx(base, props?.class, props?.className);
 
     const { variants, defaultVariants } = config;
 
@@ -83,19 +82,19 @@ export const cva =
       }, {} as Record<string, unknown>);
 
     const getCompoundVariantClassNames = config?.compoundVariants?.reduce(
-      (acc, { class: classNames, ...compoundVariantOptions }) => {
-        if (classNames == null) return acc;
-
-        return Object.entries(compoundVariantOptions).every(
+      (
+        acc,
+        { class: cvClass, className: cvClassName, ...compoundVariantOptions }
+      ) =>
+        Object.entries(compoundVariantOptions).every(
           ([key, value]) =>
             ({
               ...defaultVariants,
               ...propsWithoutUndefined,
             }[key] === value)
         )
-          ? [...acc, classNames]
-          : acc;
-      },
+          ? [...acc, cvClass, cvClassName]
+          : acc,
       [] as ClassValue[]
     );
 
@@ -103,6 +102,7 @@ export const cva =
       base,
       getVariantClassNames,
       getCompoundVariantClassNames,
-      className
+      props?.class,
+      props?.className
     );
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,13 @@
+export type ClassPropKey = "class" | "className";
 export type ClassValue = string | null | undefined | ClassValue[];
 
-export interface ClassProp {
-  class?: ClassValue;
-}
+export type ClassProp =
+  | {
+      class: ClassValue;
+      className?: never;
+    }
+  | { class?: never; className: ClassValue }
+  | { class?: never; className?: never };
 
 export type OmitUndefined<T> = T extends undefined ? never : T;
 export type StringToBoolean<T> = T extends "true" | "false" ? boolean : T;


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR adds support for the `className` prop alongside the existing `class` (but they cannot be used together, because well that would be silly really)

See https://github.com/joe-bell/cva/discussions/40

- [x] Feature
- [x] Tests
- [x] Docs

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md).
- [x] Follow the [Style Guide](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md#style-guide).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
