### PR TITLE
feat: Add support for negation and arrays in compound variants.

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1481,4 +1481,102 @@ describe("cva", () => {
       });
     });
   });
+
+  describe("with negatory compound variants", () => {
+    const button = cva(["button", "font-semibold", "border", "rounded"], {
+      variants: {
+        intent: {
+          primary: ["button--primary", "bg-blue-500"],
+          secondary: ["button--secondary", "bg-white"],
+          warning: ["button--warning", "bg-yellow-500"],
+        },
+        disabled: {
+          true: ["button--disabled"],
+          false: ["button--enabled"],
+        },
+        size: {
+          small: ["text-sm"],
+          medium: ["text-base"],
+          large: ["text-lg"],
+        },
+      },
+      compoundVariants: [
+        {
+          intent: "!primary",
+          disabled: true,
+          className: "text-black",
+        },
+      ],
+    });
+
+    type ButtonProps = CVA.VariantProps<typeof button>;
+
+    describe.each<[ButtonProps, string]>([
+      [
+        { intent: "primary", disabled: true },
+        "button font-semibold border rounded button--primary bg-blue-500 button--disabled",
+      ],
+      [
+        { intent: "secondary", disabled: true, size: "small" },
+        "button font-semibold border rounded button--secondary bg-white button--disabled text-sm text-black",
+      ],
+      [
+        { intent: "warning", disabled: true, size: "small" },
+        "button font-semibold border rounded button--warning bg-yellow-500 button--disabled text-sm text-black",
+      ],
+    ])("button(%o)", (options, expected) => {
+      test(`returns ${expected}`, () => {
+        expect(button(options)).toBe(expected);
+      });
+    });
+  });
+
+  describe("with array compound variants", () => {
+    const button = cva(["button", "font-semibold", "border", "rounded"], {
+      variants: {
+        intent: {
+          primary: ["button--primary", "bg-blue-500"],
+          secondary: ["button--secondary", "bg-white"],
+          warning: ["button--warning", "bg-yellow-500"],
+        },
+        disabled: {
+          true: ["button--disabled"],
+          false: ["button--enabled"],
+        },
+        size: {
+          small: ["text-sm"],
+          medium: ["text-base"],
+          large: ["text-lg"],
+        },
+      },
+      compoundVariants: [
+        {
+          intent: ["secondary", "warning"],
+          disabled: true,
+          className: "text-black",
+        },
+      ],
+    });
+
+    type ButtonProps = CVA.VariantProps<typeof button>;
+
+    describe.each<[ButtonProps, string]>([
+      [
+        { intent: "primary", disabled: true },
+        "button font-semibold border rounded button--primary bg-blue-500 button--disabled",
+      ],
+      [
+        { intent: "secondary", disabled: true, size: "small" },
+        "button font-semibold border rounded button--secondary bg-white button--disabled text-sm text-black",
+      ],
+      [
+        { intent: "warning", disabled: true, size: "small" },
+        "button font-semibold border rounded button--warning bg-yellow-500 button--disabled text-sm text-black",
+      ],
+    ])("button(%o)", (options, expected) => {
+      test(`returns ${expected}`, () => {
+        expect(button(options)).toBe(expected);
+      });
+    });
+  });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1482,55 +1482,6 @@ describe("cva", () => {
     });
   });
 
-  describe("with negatory compound variants", () => {
-    const button = cva(["button", "font-semibold", "border", "rounded"], {
-      variants: {
-        intent: {
-          primary: ["button--primary", "bg-blue-500"],
-          secondary: ["button--secondary", "bg-white"],
-          warning: ["button--warning", "bg-yellow-500"],
-        },
-        disabled: {
-          true: ["button--disabled"],
-          false: ["button--enabled"],
-        },
-        size: {
-          small: ["text-sm"],
-          medium: ["text-base"],
-          large: ["text-lg"],
-        },
-      },
-      compoundVariants: [
-        {
-          intent: "!primary",
-          disabled: true,
-          className: "text-black",
-        },
-      ],
-    });
-
-    type ButtonProps = CVA.VariantProps<typeof button>;
-
-    describe.each<[ButtonProps, string]>([
-      [
-        { intent: "primary", disabled: true },
-        "button font-semibold border rounded button--primary bg-blue-500 button--disabled",
-      ],
-      [
-        { intent: "secondary", disabled: true, size: "small" },
-        "button font-semibold border rounded button--secondary bg-white button--disabled text-sm text-black",
-      ],
-      [
-        { intent: "warning", disabled: true, size: "small" },
-        "button font-semibold border rounded button--warning bg-yellow-500 button--disabled text-sm text-black",
-      ],
-    ])("button(%o)", (options, expected) => {
-      test(`returns ${expected}`, () => {
-        expect(button(options)).toBe(expected);
-      });
-    });
-  });
-
   describe("with array compound variants", () => {
     const button = cva(["button", "font-semibold", "border", "rounded"], {
       variants: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,6 @@ import type {
   ClassValue,
   OmitUndefined,
   StringToBoolean,
-  AddExclamationMark,
 } from "./types";
 
 export type VariantProps<Component extends (...args: any) => any> = Omit<
@@ -31,7 +30,7 @@ type ConfigSchema = Record<string, Record<string, ClassValue>>;
 
 type ConfigVariants<T extends ConfigSchema> = {
   [Variant in keyof T]?:
-    | StringToBoolean<keyof T[Variant] | AddExclamationMark<keyof T[Variant]>>
+    | StringToBoolean<keyof T[Variant]>
     | StringToBoolean<keyof T[Variant]>[]
     | null;
 };
@@ -96,15 +95,7 @@ export const cva =
         { class: cvClass, className: cvClassName, ...compoundVariantOptions }
       ) =>
         Object.entries(compoundVariantOptions).every(([key, value]) => {
-          // If compound value is a string starting with an exclamation mark, ensure the prop does NOT equal this value.
-          if (typeof value === "string" && value.startsWith("!")) {
-            return (
-              defaultVariantsAndPropsWithoutUndefined[key] !== value.slice(1)
-            );
-          }
-
           // If compound value is an array, ensure that the current value of this prop is included in the array.
-          // This array can NEVER include a negatory value, since we can not guess if that would mean 'AND' or 'OR'.
           if (Array.isArray(value)) {
             return value.includes(defaultVariantsAndPropsWithoutUndefined[key]);
           }

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,13 +11,3 @@ export type ClassProp =
 
 export type OmitUndefined<T> = T extends undefined ? never : T;
 export type StringToBoolean<T> = T extends "true" | "false" ? boolean : T;
-
-export type AddExclamationMark<T extends unknown> =
-  // If T is a boolean string, don't add negation to this.
-  T extends "true" | "false"
-    ? T
-    : // If it's a number or string, negation is supported.
-    T extends string | number
-    ? `!${T}`
-    : // Any other type is returned as is.
-      T;

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,3 +11,13 @@ export type ClassProp =
 
 export type OmitUndefined<T> = T extends undefined ? never : T;
 export type StringToBoolean<T> = T extends "true" | "false" ? boolean : T;
+
+export type AddExclamationMark<T extends unknown> =
+  // If T is a boolean string, don't add negation to this.
+  T extends "true" | "false"
+    ? T
+    : // If it's a number or string, negation is supported.
+    T extends string | number
+    ? `!${T}`
+    : // Any other type is returned as is.
+      T;


### PR DESCRIPTION
### Description

As per discussion #65 I've added the functionality of adding array variants to the `compoundVariants`.  Really looking forward to hear what you think about this @joe-bell. I think this would be a super nice addition 🔥 

It looks like this: 

#### Array variants
In this example the `compoundVariant` will apply to components with `intent` set to either `secondary` or `warning` and `disabled: true`. 

![CleanShot 2022-11-18 at 20 29 32@2x](https://user-images.githubusercontent.com/2969573/202786885-c6d7cbde-700d-4e74-8601-493a36333ec1.jpg)


### What is the purpose of this pull request?

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md).
- [x] Follow the [Style Guide](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md#style-guide).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).

### Possible things we might still want to add
- More unit tests? 