### PR TITLE
Target Multiple Variant Options within Compound Variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,56 @@ button({ intent: "secondary", size: "small" });
 // => "font-semibold border rounded bg-white text-gray-800 border-gray-400 hover:bg-gray-100 text-sm py-1 px-2"
 ```
 
+### Compound Variants
+
+Variants that apply when multiple other variant conditions are met.
+
+```ts
+// components/button.ts
+import { cva } from "class-variance-authority";
+
+const button = cva("…", {
+  variants: {
+    intent: { primary: "…", secondary: "…" },
+    size: { small: "…", medium: "…" },
+  },
+  compoundVariants: [
+    // Applied via:
+    //   `button({ intent: "primary", size: "medium" })`
+    {
+      intent: "primary",
+      size: "medium",
+      class: "…",
+    },
+  ],
+});
+```
+
+#### Targeting Multiple Variant Conditions
+
+```ts
+// components/button.ts
+import { cva } from "class-variance-authority";
+
+const button = cva("…", {
+  variants: {
+    intent: { primary: "…", secondary: "…" },
+    size: { small: "…", medium: "…" },
+  },
+  compoundVariants: [
+    // Applied via:
+    //   `button({ intent: "primary", size: "medium" })`
+    //     or
+    //   `button({ intent: "secondary", size: "medium" })`
+    {
+      intent: ["primary", "secondary"],
+      size: "medium",
+      class: "…",
+    },
+  ],
+});
+```
+
 ### Additional Classes
 
 All `cva` components provide an optional `class` **or** `className` prop, which can be used to pass additional classes to the component.

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1503,7 +1503,6 @@ describe("with array compound variants", () => {
     },
     compoundVariants: [
       {
-        // @ts-expect-error
         intent: ["secondary", "warning"],
         disabled: true,
         className: "text-black",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1482,3 +1482,53 @@ describe("cva", () => {
     });
   });
 });
+
+describe("with array compound variants", () => {
+  const button = cva(["button", "font-semibold", "border", "rounded"], {
+    variants: {
+      intent: {
+        primary: ["button--primary", "bg-blue-500"],
+        secondary: ["button--secondary", "bg-white"],
+        warning: ["button--warning", "bg-yellow-500"],
+      },
+      disabled: {
+        true: ["button--disabled"],
+        false: ["button--enabled"],
+      },
+      size: {
+        small: ["text-sm"],
+        medium: ["text-base"],
+        large: ["text-lg"],
+      },
+    },
+    compoundVariants: [
+      {
+        // @ts-expect-error
+        intent: ["secondary", "warning"],
+        disabled: true,
+        className: "text-black",
+      },
+    ],
+  });
+
+  type ButtonProps = CVA.VariantProps<typeof button>;
+
+  describe.each<[ButtonProps, string]>([
+    [
+      { intent: "primary", disabled: true },
+      "button font-semibold border rounded button--primary bg-blue-500 button--disabled",
+    ],
+    [
+      { intent: "secondary", disabled: true, size: "small" },
+      "button font-semibold border rounded button--secondary bg-white button--disabled text-sm text-black",
+    ],
+    [
+      { intent: "warning", disabled: true, size: "small" },
+      "button font-semibold border rounded button--warning bg-yellow-500 button--disabled text-sm text-black",
+    ],
+  ])("button(%o)", (options, expected) => {
+    test(`returns ${expected}`, () => {
+      expect(button(options)).toBe(expected);
+    });
+  });
+});

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -462,6 +462,15 @@ describe("cva", () => {
               disabled: true,
               class: "button--warning-disabled text-black",
             },
+            {
+              intent: ["warning", "danger"],
+              class: "button--warning-danger !border-red-500",
+            },
+            {
+              intent: ["warning", "danger"],
+              size: "medium",
+              class: "button--warning-danger-medium",
+            },
           ],
           defaultVariants: {
             m: 0,
@@ -514,6 +523,15 @@ describe("cva", () => {
               intent: "warning",
               disabled: true,
               className: "button--warning-disabled text-black",
+            },
+            {
+              intent: ["warning", "danger"],
+              className: "button--warning-danger !border-red-500",
+            },
+            {
+              intent: ["warning", "danger"],
+              size: "medium",
+              className: "button--warning-danger-medium",
             },
           ],
           defaultVariants: {
@@ -588,6 +606,15 @@ describe("cva", () => {
               disabled: true,
               class: ["button--warning-disabled", "text-black"],
             },
+            {
+              intent: ["warning", "danger"],
+              class: ["button--warning-danger", "!border-red-500"],
+            },
+            {
+              intent: ["warning", "danger"],
+              size: "medium",
+              class: ["button--warning-danger-medium"],
+            },
           ],
           defaultVariants: {
             m: 0,
@@ -660,6 +687,15 @@ describe("cva", () => {
               disabled: true,
               className: ["button--warning-disabled", "text-black"],
             },
+            {
+              intent: ["warning", "danger"],
+              className: "button--warning-danger !border-red-500",
+            },
+            {
+              intent: ["warning", "danger"],
+              size: "medium",
+              className: "button--warning-danger-medium",
+            },
           ],
           defaultVariants: {
             m: 0,
@@ -722,15 +758,15 @@ describe("cva", () => {
         ],
         [
           { intent: "danger", size: "medium" },
-          "button font-semibold border rounded button--danger bg-red-500 text-white border-transparent hover:bg-red-600 button--enabled cursor-pointer button--medium text-base py-2 px-4 m-0",
+          "button font-semibold border rounded button--danger bg-red-500 text-white border-transparent hover:bg-red-600 button--enabled cursor-pointer button--medium text-base py-2 px-4 m-0 button--warning-danger !border-red-500 button--warning-danger-medium",
         ],
         [
           { intent: "warning", size: "large" },
-          "button font-semibold border rounded button--warning bg-yellow-500 border-transparent hover:bg-yellow-600 button--enabled cursor-pointer button--large text-lg py-2.5 px-4 m-0 button--warning-enabled text-gray-800",
+          "button font-semibold border rounded button--warning bg-yellow-500 border-transparent hover:bg-yellow-600 button--enabled cursor-pointer button--large text-lg py-2.5 px-4 m-0 button--warning-enabled text-gray-800 button--warning-danger !border-red-500",
         ],
         [
           { intent: "warning", size: "large", disabled: true },
-          "button font-semibold border rounded button--warning bg-yellow-500 border-transparent hover:bg-yellow-600 button--disabled opacity-050 cursor-not-allowed button--large text-lg py-2.5 px-4 m-0 button--warning-disabled text-black",
+          "button font-semibold border rounded button--warning bg-yellow-500 border-transparent hover:bg-yellow-600 button--disabled opacity-050 cursor-not-allowed button--large text-lg py-2.5 px-4 m-0 button--warning-disabled text-black button--warning-danger !border-red-500",
         ],
         [
           { intent: "primary", m: 0 },
@@ -814,6 +850,15 @@ describe("cva", () => {
               disabled: true,
               class: "button--warning-disabled text-black",
             },
+            {
+              intent: ["warning", "danger"],
+              class: "button--warning-danger !border-red-500",
+            },
+            {
+              intent: ["warning", "danger"],
+              size: "medium",
+              class: "button--warning-danger-medium",
+            },
           ],
         }
       );
@@ -856,6 +901,15 @@ describe("cva", () => {
               intent: "warning",
               disabled: true,
               className: "button--warning-disabled text-black",
+            },
+            {
+              intent: ["warning", "danger"],
+              className: "button--warning-danger !border-red-500",
+            },
+            {
+              intent: ["warning", "danger"],
+              size: "medium",
+              className: "button--warning-danger-medium",
             },
           ],
         }
@@ -920,6 +974,15 @@ describe("cva", () => {
               disabled: true,
               class: ["button--warning-disabled", "text-black"],
             },
+            {
+              intent: ["warning", "danger"],
+              class: ["button--warning-danger", "!border-red-500"],
+            },
+            {
+              intent: ["warning", "danger"],
+              size: "medium",
+              class: ["button--warning-danger-medium"],
+            },
           ],
         }
       );
@@ -970,17 +1033,26 @@ describe("cva", () => {
             {
               intent: "primary",
               size: "medium",
-              class: ["button--primary-medium", "uppercase"],
+              className: ["button--primary-medium", "uppercase"],
             },
             {
               intent: "warning",
               disabled: false,
-              class: ["button--warning-enabled", "text-gray-800"],
+              className: ["button--warning-enabled", "text-gray-800"],
             },
             {
               intent: "warning",
               disabled: true,
-              class: ["button--warning-disabled", "text-black"],
+              className: ["button--warning-disabled", "text-black"],
+            },
+            {
+              intent: ["warning", "danger"],
+              className: ["button--warning-danger", "!border-red-500"],
+            },
+            {
+              intent: ["warning", "danger"],
+              size: "medium",
+              className: ["button--warning-danger-medium"],
             },
           ],
         }
@@ -1036,23 +1108,23 @@ describe("cva", () => {
         ],
         [
           { intent: "danger", size: "medium" },
-          "button font-semibold border rounded button--danger bg-red-500 text-white border-transparent hover:bg-red-600 button--medium text-base py-2 px-4",
+          "button font-semibold border rounded button--danger bg-red-500 text-white border-transparent hover:bg-red-600 button--medium text-base py-2 px-4 button--warning-danger !border-red-500 button--warning-danger-medium",
         ],
         [
           { intent: "warning", size: "large" },
-          "button font-semibold border rounded button--warning bg-yellow-500 border-transparent hover:bg-yellow-600 button--large text-lg py-2.5 px-4",
+          "button font-semibold border rounded button--warning bg-yellow-500 border-transparent hover:bg-yellow-600 button--large text-lg py-2.5 px-4 button--warning-danger !border-red-500",
         ],
         [
           { intent: "warning", size: "large", disabled: null },
-          "button font-semibold border rounded button--warning bg-yellow-500 border-transparent hover:bg-yellow-600 button--large text-lg py-2.5 px-4",
+          "button font-semibold border rounded button--warning bg-yellow-500 border-transparent hover:bg-yellow-600 button--large text-lg py-2.5 px-4 button--warning-danger !border-red-500",
         ],
         [
           { intent: "warning", size: "large", disabled: true },
-          "button font-semibold border rounded button--warning bg-yellow-500 border-transparent hover:bg-yellow-600 button--disabled opacity-050 cursor-not-allowed button--large text-lg py-2.5 px-4 button--warning-disabled text-black",
+          "button font-semibold border rounded button--warning bg-yellow-500 border-transparent hover:bg-yellow-600 button--disabled opacity-050 cursor-not-allowed button--large text-lg py-2.5 px-4 button--warning-disabled text-black button--warning-danger !border-red-500",
         ],
         [
           { intent: "warning", size: "large", disabled: false },
-          "button font-semibold border rounded button--warning bg-yellow-500 border-transparent hover:bg-yellow-600 button--enabled cursor-pointer button--large text-lg py-2.5 px-4 button--warning-enabled text-gray-800",
+          "button font-semibold border rounded button--warning bg-yellow-500 border-transparent hover:bg-yellow-600 button--enabled cursor-pointer button--large text-lg py-2.5 px-4 button--warning-enabled text-gray-800 button--warning-danger !border-red-500",
         ],
         // !@TODO Add type "extractor" including class prop
         [
@@ -1124,6 +1196,15 @@ describe("cva", () => {
               disabled: true,
               class: "button--warning-disabled text-black",
             },
+            {
+              intent: ["warning", "danger"],
+              class: "button--warning-danger !border-red-500",
+            },
+            {
+              intent: ["warning", "danger"],
+              size: "medium",
+              class: "button--warning-danger-medium",
+            },
           ],
           defaultVariants: {
             disabled: false,
@@ -1171,6 +1252,15 @@ describe("cva", () => {
               intent: "warning",
               disabled: true,
               className: "button--warning-disabled text-black",
+            },
+            {
+              intent: ["warning", "danger"],
+              className: "button--warning-danger !border-red-500",
+            },
+            {
+              intent: ["warning", "danger"],
+              size: "medium",
+              className: "button--warning-danger-medium",
             },
           ],
           defaultVariants: {
@@ -1240,6 +1330,15 @@ describe("cva", () => {
               disabled: true,
               class: ["button--warning-disabled", "text-black"],
             },
+            {
+              intent: ["warning", "danger"],
+              class: ["button--warning-danger", "!border-red-500"],
+            },
+            {
+              intent: ["warning", "danger"],
+              size: "medium",
+              class: ["button--warning-danger-medium"],
+            },
           ],
           defaultVariants: {
             disabled: false,
@@ -1295,17 +1394,26 @@ describe("cva", () => {
             {
               intent: "primary",
               size: "medium",
-              class: ["button--primary-medium", "uppercase"],
+              className: ["button--primary-medium", "uppercase"],
             },
             {
               intent: "warning",
               disabled: false,
-              class: ["button--warning-enabled", "text-gray-800"],
+              className: ["button--warning-enabled", "text-gray-800"],
             },
             {
               intent: "warning",
               disabled: true,
-              class: ["button--warning-disabled", "text-black"],
+              className: ["button--warning-disabled", "text-black"],
+            },
+            {
+              intent: ["warning", "danger"],
+              className: ["button--warning-danger", "!border-red-500"],
+            },
+            {
+              intent: ["warning", "danger"],
+              size: "medium",
+              className: ["button--warning-danger-medium"],
             },
           ],
           defaultVariants: {
@@ -1369,11 +1477,11 @@ describe("cva", () => {
         ],
         [
           { intent: "danger", size: "medium" },
-          "button font-semibold border rounded button--danger bg-red-500 text-white border-transparent hover:bg-red-600 button--enabled cursor-pointer button--medium text-base py-2 px-4",
+          "button font-semibold border rounded button--danger bg-red-500 text-white border-transparent hover:bg-red-600 button--enabled cursor-pointer button--medium text-base py-2 px-4 button--warning-danger !border-red-500 button--warning-danger-medium",
         ],
         [
           { intent: "warning", size: "large" },
-          "button font-semibold border rounded button--warning bg-yellow-500 border-transparent hover:bg-yellow-600 button--enabled cursor-pointer button--large text-lg py-2.5 px-4 button--warning-enabled text-gray-800",
+          "button font-semibold border rounded button--warning bg-yellow-500 border-transparent hover:bg-yellow-600 button--enabled cursor-pointer button--large text-lg py-2.5 px-4 button--warning-enabled text-gray-800 button--warning-danger !border-red-500",
         ],
         [
           {
@@ -1381,15 +1489,15 @@ describe("cva", () => {
             size: "large",
             disabled: null,
           },
-          "button font-semibold border rounded button--warning bg-yellow-500 border-transparent hover:bg-yellow-600 button--large text-lg py-2.5 px-4",
+          "button font-semibold border rounded button--warning bg-yellow-500 border-transparent hover:bg-yellow-600 button--large text-lg py-2.5 px-4 button--warning-danger !border-red-500",
         ],
         [
           { intent: "warning", size: "large", disabled: true },
-          "button font-semibold border rounded button--warning bg-yellow-500 border-transparent hover:bg-yellow-600 button--disabled opacity-050 cursor-not-allowed button--large text-lg py-2.5 px-4 button--warning-disabled text-black",
+          "button font-semibold border rounded button--warning bg-yellow-500 border-transparent hover:bg-yellow-600 button--disabled opacity-050 cursor-not-allowed button--large text-lg py-2.5 px-4 button--warning-disabled text-black button--warning-danger !border-red-500",
         ],
         [
           { intent: "warning", size: "large", disabled: false },
-          "button font-semibold border rounded button--warning bg-yellow-500 border-transparent hover:bg-yellow-600 button--enabled cursor-pointer button--large text-lg py-2.5 px-4 button--warning-enabled text-gray-800",
+          "button font-semibold border rounded button--warning bg-yellow-500 border-transparent hover:bg-yellow-600 button--enabled cursor-pointer button--large text-lg py-2.5 px-4 button--warning-enabled text-gray-800 button--warning-danger !border-red-500",
         ],
         // !@TODO Add type "extractor" including class prop
         [
@@ -1479,55 +1587,6 @@ describe("cva", () => {
       test(`returns ${expected}`, () => {
         expect(card(options)).toBe(expected);
       });
-    });
-  });
-});
-
-describe("with array compound variants", () => {
-  const button = cva(["button", "font-semibold", "border", "rounded"], {
-    variants: {
-      intent: {
-        primary: ["button--primary", "bg-blue-500"],
-        secondary: ["button--secondary", "bg-white"],
-        warning: ["button--warning", "bg-yellow-500"],
-      },
-      disabled: {
-        true: ["button--disabled"],
-        false: ["button--enabled"],
-      },
-      size: {
-        small: ["text-sm"],
-        medium: ["text-base"],
-        large: ["text-lg"],
-      },
-    },
-    compoundVariants: [
-      {
-        intent: ["secondary", "warning"],
-        disabled: true,
-        className: "text-black",
-      },
-    ],
-  });
-
-  type ButtonProps = CVA.VariantProps<typeof button>;
-
-  describe.each<[ButtonProps, string]>([
-    [
-      { intent: "primary", disabled: true },
-      "button font-semibold border rounded button--primary bg-blue-500 button--disabled",
-    ],
-    [
-      { intent: "secondary", disabled: true, size: "small" },
-      "button font-semibold border rounded button--secondary bg-white button--disabled text-sm text-black",
-    ],
-    [
-      { intent: "warning", disabled: true, size: "small" },
-      "button font-semibold border rounded button--warning bg-yellow-500 button--disabled text-sm text-black",
-    ],
-  ])("button(%o)", (options, expected) => {
-    test(`returns ${expected}`, () => {
-      expect(button(options)).toBe(expected);
     });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,18 +81,25 @@ export const cva =
         return acc;
       }, {} as Record<string, unknown>);
 
+    const defaultVariantsAndPropsWithoutUndefined = {
+      ...defaultVariants,
+      ...propsWithoutUndefined,
+    };
+
     const getCompoundVariantClassNames = config?.compoundVariants?.reduce(
       (
         acc,
         { class: cvClass, className: cvClassName, ...compoundVariantOptions }
       ) =>
-        Object.entries(compoundVariantOptions).every(
-          ([key, value]) =>
-            ({
-              ...defaultVariants,
-              ...propsWithoutUndefined,
-            }[key] === value)
-        )
+        Object.entries(compoundVariantOptions).every(([key, value]) => {
+          // If compound value is an array, ensure that the current value of this prop is included in the array.
+          if (Array.isArray(value)) {
+            return value.includes(defaultVariantsAndPropsWithoutUndefined[key]);
+          }
+
+          // Default behavior is checking that the value of a prop DOES equal the value set in the compound variant.
+          return defaultVariantsAndPropsWithoutUndefined[key] === value;
+        })
           ? [...acc, cvClass, cvClassName]
           : acc,
       [] as ClassValue[]

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,13 +31,18 @@ type ConfigSchema = Record<string, Record<string, ClassValue>>;
 type ConfigVariants<T extends ConfigSchema> = {
   [Variant in keyof T]?: StringToBoolean<keyof T[Variant]> | null;
 };
+type ConfigVariantsMulti<T extends ConfigSchema> = {
+  [Variant in keyof T]?:
+    | StringToBoolean<keyof T[Variant]>
+    | StringToBoolean<keyof T[Variant]>[];
+};
 
 type Config<T> = T extends ConfigSchema
   ? {
       variants?: T;
       defaultVariants?: ConfigVariants<T>;
       compoundVariants?: (T extends ConfigSchema
-        ? ConfigVariants<T> & ClassProp
+        ? (ConfigVariants<T> | ConfigVariantsMulti<T>) & ClassProp
         : ClassProp)[];
     }
   : never;

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,25 +86,24 @@ export const cva =
         return acc;
       }, {} as Record<string, unknown>);
 
-    const defaultVariantsAndPropsWithoutUndefined = {
-      ...defaultVariants,
-      ...propsWithoutUndefined,
-    };
-
     const getCompoundVariantClassNames = config?.compoundVariants?.reduce(
       (
         acc,
         { class: cvClass, className: cvClassName, ...compoundVariantOptions }
       ) =>
-        Object.entries(compoundVariantOptions).every(([key, value]) => {
-          // If compound value is an array, ensure that the current value of this prop is included in the array.
-          if (Array.isArray(value)) {
-            return value.includes(defaultVariantsAndPropsWithoutUndefined[key]);
-          }
-
-          // Default behavior is checking that the value of a prop DOES equal the value set in the compound variant.
-          return defaultVariantsAndPropsWithoutUndefined[key] === value;
-        })
+        Object.entries(compoundVariantOptions).every(([key, value]) =>
+          Array.isArray(value)
+            ? value.includes(
+                {
+                  ...defaultVariants,
+                  ...propsWithoutUndefined,
+                }[key]
+              )
+            : {
+                ...defaultVariants,
+                ...propsWithoutUndefined,
+              }[key] === value
+        )
           ? [...acc, cvClass, cvClassName]
           : acc,
       [] as ClassValue[]


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

> Follows up on @JeroenReumkens' wonderful work in #66

This PR introduces the ability to target multiple variants at once within `compoundVariants` (whilst preserving type-safety)

```ts
const button = cva("button", {
  variants: {
    intent: {
      primary: "button--primary",
      secondary: "button--secondary",
      warning: "button--warning",
    },
    disabled: {
      true: "button--disabled",
      false: "button--enabled",
    },
  },
  compoundVariants: [
    {
      // ✨ apply to `secondary` and `warning` intents ✨
      intent: ["secondary", "warning"],
      disabled: true,
      class: "text-black",
    },
  ],
});
```

#### Tasks

- [x] Documentation
- [x] Fix types from #66 
- [x] Refine and reduce bundlesize
- [x] Refine and cleanup tests

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

#66 

---

### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md).
- [x] Follow the [Style Guide](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md#style-guide).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
