### PR TITLE
Read me React type fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,7 +580,7 @@ const button = cva(base, {
 });
 
 export interface ButtonProps
-  extends React.HTMLAttributes<HTMLButtonElement>,
+  extends React.HTMLProps<HTMLButtonElement>,
     VariantProps<typeof button> {}
 
 export const Button: React.FC<ButtonProps> = ({
@@ -633,7 +633,7 @@ const button = cva("button", {
 });
 
 export interface ButtonProps
-  extends React.HTMLAttributes<HTMLButtonElement>,
+  extends React.HTMLProps<HTMLButtonElement>,
     VariantProps<typeof button> {}
 
 export const Button: React.FC<ButtonProps> = ({

--- a/README.md
+++ b/README.md
@@ -580,7 +580,7 @@ const button = cva(base, {
 });
 
 export interface ButtonProps
-  extends React.HTMLProps<HTMLButtonElement>,
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof button> {}
 
 export const Button: React.FC<ButtonProps> = ({
@@ -633,7 +633,7 @@ const button = cva("button", {
 });
 
 export interface ButtonProps
-  extends React.HTMLProps<HTMLButtonElement>,
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof button> {}
 
 export const Button: React.FC<ButtonProps> = ({


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This pr suggests using `React.{tag}HTMLAttributes<T>` instead of `ReactHTMLAttributes` for better-typed custom components

### Additional context

For example, let's say I have this component

```jsx
   <Input placeholder='Email' type='email' />
```

Typescript will error when i try to use the `type` attribute.
By using  `React.InputHTMLAttributes<T>`  the error is gone, also no other type is compromised.

---

### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md).
- [ ] Follow the [Style Guide](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md#style-guide).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
