### PR TITLE
docs: add CSS flavour mention to examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,7 +448,7 @@ const className = cx(classes);
 > ⚠️ Warning: The examples below are purely demonstrative and haven't been tested thoroughly (yet)
 
 <details>
-  <summary>Astro</summary>
+  <summary>Astro (with Tailwind)</summary>
 
 ```astro
 ---
@@ -727,7 +727,7 @@ export const Button: React.FC<ButtonProps> = ({
 </details>
 
 <details>
-    <summary>Svelte</summary>
+    <summary>Svelte (with BEM)</summary>
 
 ```svelte
 <!-- button.svelte -->
@@ -778,7 +778,7 @@ export const Button: React.FC<ButtonProps> = ({
 </details>
 
 <details>
-    <summary>Vue 3</summary>
+    <summary>Vue 3 (with BEM)</summary>
 
 ```vue
 <!-- button.vue -->


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Most [examples](https://github.com/joe-bell/cva#examples) specify which CSS framework/methodology they illustrate, except for Astro, Svelte & Vue 3 examples.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

IMHO, for consistency and clarity it can be beneficial to always mention the flavour of the CSS used in the examples (it might even incentivise people to write more examples?).

Anyway, clearly not critical, just a suggestion let me know what you think :)
<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md).
- [x] Follow the [Style Guide](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md#style-guide).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
