### PR TITLE
Introduce `/experimental` Export

### DIFF
--- a/.config/.syncpackrc
+++ b/.config/.syncpackrc
@@ -1,30 +1,4 @@
 {
   "workspace": false,
-  "peer": false,
-  "sortFirst": [
-    "private",
-    "name",
-    "version",
-    "description",
-    "author",
-    "license",
-    "funding",
-    "repository",
-    "bugs",
-    "homepage",
-    "keywords",
-    "source",
-    "main",
-    "module",
-    "exports",
-    "typings",
-    "typesVersions",
-    "files",
-    "scripts",
-    "browserslist",
-    "peerDependencies",
-    "peerDependenciesMeta",
-    "dependencies",
-    "devDependencies"
-  ]
+  "peer": false
 }

--- a/.config/lint-staged.config.mjs
+++ b/.config/lint-staged.config.mjs
@@ -4,10 +4,5 @@ export default {
       .map((filename) => `'${filename}'`)
       .join(" ")}`,
   "**/*.{js,jsx,ts,tsx}": () => "pnpm tsc",
-  "**/package.json": (filenames) => [
-    "pnpm syncpack:list-mismatches",
-    `pnpm syncpack:format -- ${filenames
-      .map((filename) => `--source '${filename}'`)
-      .join(" ")}`,
-  ],
+  "**/package.json": (filenames) => "pnpm syncpack:list-mismatches",
 };

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+  plugins: [
+    require.resolve("prettier-plugin-packagejson"),
+    require.resolve("prettier-plugin-tailwindcss"),
+  ],
+  pluginSearchDirs: ["."],
+};

--- a/README.md
+++ b/README.md
@@ -423,6 +423,19 @@ const component = cva("base", options);
    - `defaultVariants`: set default values for previously defined variants.  
      _note: these default values can be removed completely by setting the variant as `null`_
 
+<details>
+
+<summary><code>class-variance-authority/experimental</code></summary>
+
+1. `options`
+   - `base`: the base class name (`string`, `string[]` or `null`)
+   - `variants`: your variants schema
+   - `compoundVariants`: variants based on a combination of previously defined variants
+   - `defaultVariants`: set default values for previously defined variants.  
+     _note: these default values can be removed completely by setting the variant as `null`_
+
+</details>
+
 #### Returns
 
 A `cva` component function

--- a/README.md
+++ b/README.md
@@ -432,7 +432,7 @@ const component = cva("base", options);
    - `variants`: your variants schema
    - `compoundVariants`: variants based on a combination of previously defined variants
    - `defaultVariants`: set default values for previously defined variants.  
-     _note: these default values can be removed completely by setting the variant as `null`_
+     _note: these default values can be removed completely by setting the variant as `"unset"`_
 
 </details>
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "preinstall": "npx only-allow pnpm",
     "prepare": "husky install",
     "prettier": "prettier --ignore-unknown --no-error-on-unmatched-pattern",
-    "syncpack:format": "syncpack format --config .config/.syncpackrc",
     "syncpack:list-mismatches": "syncpack list-mismatches --config .config/.syncpackrc",
     "test": "pnpm run -r --parallel test",
     "tsc": "pnpm run -r --parallel tsc"
@@ -20,6 +19,8 @@
     "lint-staged": "13.0.1",
     "npm-run-all": "4.1.5",
     "prettier": "2.6.2",
+    "prettier-plugin-packagejson": "2.4.2",
+    "prettier-plugin-tailwindcss": "0.2.2",
     "syncpack": "8.4.11"
   }
 }

--- a/packages/class-variance-authority/package.json
+++ b/packages/class-variance-authority/package.json
@@ -2,11 +2,6 @@
   "name": "class-variance-authority",
   "version": "0.4.0",
   "description": "Class Variance Authority 🧬",
-  "author": "Joe Bell (https://joebell.co.uk)",
-  "funding": "https://joebell.co.uk",
-  "repository": "https://github.com/joe-bell/cva.git",
-  "bugs": "https://github.com/joe-bell/cva/issues",
-  "homepage": "https://github.com/joe-bell/cva#readme",
   "keywords": [
     "Class Variance Authority",
     "class-variance-authority",
@@ -19,33 +14,54 @@
     "vanilla-extract",
     "variants"
   ],
-  "main": "dist/index.cjs.js",
-  "module": "dist/index.esm.js",
-  "typings": "dist/index.d.ts",
+  "homepage": "https://github.com/joe-bell/cva#readme",
+  "bugs": "https://github.com/joe-bell/cva/issues",
+  "repository": "https://github.com/joe-bell/cva.git",
+  "funding": "https://joebell.co.uk",
+  "author": "Joe Bell (https://joebell.co.uk)",
+  "exports": {
+    ".": {
+      "import": "./dist/index.esm.js",
+      "require": "./dist/index.cjs.js"
+    },
+    "./experimental": {
+      "import": "./dist/experimental/index.esm.js",
+      "require": "./dist/experimental/index.cjs.js"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/index.d.ts"
+      ],
+      "experimental": [
+        "./dist/experimental/index.d.ts"
+      ]
+    }
+  },
   "files": [
     "dist/*.js",
     "dist/*.js.map",
-    "dist/*.d.ts"
+    "dist/*.d.ts",
+    "dist/experimental/*.js",
+    "dist/experimental/*.js.map",
+    "dist/experimental/*.d.ts"
   ],
   "scripts": {
-    "build": "npm-run-all build:*",
-    "build:cjs": "swc ./src/index.ts --config-file ./.config/.swcrc -o dist/index.cjs.js -C module.type=commonjs",
-    "build:esm": "swc ./src/index.ts --config-file ./.config/.swcrc -o dist/index.esm.js -C module.type=es6 ",
+    "build": "run-p build:**",
+    "build:cjs:stable": "swc ./src/index.ts --config-file ./.config/.swcrc -o dist/index.cjs.js -C module.type=commonjs",
+    "build:esm:stable": "swc ./src/index.ts --config-file ./.config/.swcrc -o dist/index.esm.js -C module.type=es6 ",
+    "build:cjs:experimental": "swc ./src/experimental/index.ts --config-file ./.config/.swcrc -o dist/experimental/index.cjs.js -C module.type=commonjs",
+    "build:esm:experimental": "swc ./src/experimental/index.ts --config-file ./.config/.swcrc -o dist/experimental/index.esm.js -C module.type=es6 ",
     "build:tsc": "tsc --project .config/tsconfig.build.json",
     "dev": "jest --config .config/jest.config.ts --watch",
-    "prepublishOnly": "npm run build",
+    "prepublishOnly": "pnpm build",
     "test": "run-p test:*",
     "test:jest": "jest --config .config/jest.config.ts --coverage",
-    "test:size": "run-p build:cjs build:esm && npx bundlesize -f 'dist/*.js' -s 850B",
+    "test:size": "pnpm build && run-p test:size:*",
+    "test:size:stable": "pnpx bundlesize -f 'dist/*.js' -s 850B",
+    "test:size:experimental": "pnpx bundlesize -f 'dist/experimental/*.js' -s 880B",
     "tsc": "tsc --project tsconfig.json --noEmit"
-  },
-  "peerDependencies": {
-    "typescript": ">= 4.5.5 < 5"
-  },
-  "peerDependenciesMeta": {
-    "typescript": {
-      "optional": true
-    }
   },
   "devDependencies": {
     "@jest/types": "28.1.1",
@@ -63,5 +79,13 @@
     "react-dom": "18.1.0",
     "ts-node": "10.8.1",
     "typescript": "4.7.3"
+  },
+  "peerDependencies": {
+    "typescript": ">= 4.5.5 < 5"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
   }
 }

--- a/packages/class-variance-authority/src/experimental/index.test.ts
+++ b/packages/class-variance-authority/src/experimental/index.test.ts
@@ -1,0 +1,1572 @@
+import type * as CVA from "./";
+import { cva, cx } from "./";
+
+describe("cx", () => {
+  describe.each<CVA.CxOptions>([
+    [null, ""],
+    [undefined, ""],
+    [["foo", undefined, "bar", undefined, "baz"], "foo bar baz"],
+    [
+      [
+        "foo",
+        [
+          undefined,
+          ["bar"],
+          [
+            undefined,
+            [
+              "baz",
+              "qux",
+              "quux",
+              "quuz",
+              [[[[[[[[["corge", "grault"]]]]], "garply"]]]],
+            ],
+          ],
+        ],
+      ],
+      "foo bar baz qux quux quuz corge grault garply",
+    ],
+  ])("cx(%o)", (options, expected) => {
+    test(`returns ${expected}`, () => {
+      expect(cx(options)).toBe(expected);
+    });
+  });
+});
+
+describe("cva", () => {
+  describe("without base", () => {
+    describe("without anything", () => {
+      test("empty", () => {
+        // @ts-expect-error
+        const example = cva();
+        expect(example()).toBe("");
+        expect(
+          example({
+            // @ts-expect-error
+            aCheekyInvalidProp: "lol",
+          })
+        ).toBe("");
+        expect(example({ class: "adhoc-class" })).toBe("adhoc-class");
+        expect(example({ className: "adhoc-className" })).toBe(
+          "adhoc-className"
+        );
+        expect(
+          example({
+            // @ts-expect-error
+            class: "adhoc-class",
+            // @ts-expect-error
+            className: "adhoc-className",
+          })
+        ).toBe("adhoc-class adhoc-className");
+      });
+
+      test("undefined", () => {
+        // @ts-expect-error
+        const example = cva(undefined);
+        expect(example()).toBe("");
+        expect(
+          example({
+            // @ts-expect-error
+            aCheekyInvalidProp: "lol",
+          })
+        ).toBe("");
+        expect(example({ class: "adhoc-class" })).toBe("adhoc-class");
+        expect(example({ className: "adhoc-className" })).toBe(
+          "adhoc-className"
+        );
+        expect(
+          example({
+            // @ts-expect-error
+            class: "adhoc-class",
+            // @ts-expect-error
+            className: "adhoc-className",
+          })
+        ).toBe("adhoc-class adhoc-className");
+      });
+
+      test("null", () => {
+        const example = cva(
+          // @ts-expect-error
+          null
+        );
+        expect(example()).toBe("");
+        expect(
+          example({
+            // @ts-expect-error
+            aCheekyInvalidProp: "lol",
+          })
+        ).toBe("");
+        expect(example({ class: "adhoc-class" })).toBe("adhoc-class");
+        expect(example({ className: "adhoc-className" })).toBe(
+          "adhoc-className"
+        );
+        expect(
+          example({
+            // @ts-expect-error
+            class: "adhoc-class",
+            // @ts-expect-error
+            className: "adhoc-className",
+          })
+        ).toBe("adhoc-class adhoc-className");
+      });
+    });
+
+    describe("without defaults", () => {
+      const buttonWithoutBaseWithoutDefaultsString = cva({
+        variants: {
+          intent: {
+            primary:
+              "button--primary bg-blue-500 text-white border-transparent hover:bg-blue-600",
+            secondary:
+              "button--secondary bg-white text-gray-800 border-gray-400 hover:bg-gray-100",
+            warning:
+              "button--warning bg-yellow-500 border-transparent hover:bg-yellow-600",
+            danger:
+              "button--danger bg-red-500 text-white border-transparent hover:bg-red-600",
+          },
+          disabled: {
+            true: "button--disabled opacity-050 cursor-not-allowed",
+            false: "button--enabled cursor-pointer",
+          },
+          size: {
+            small: "button--small text-sm py-1 px-2",
+            medium: "button--medium text-base py-2 px-4",
+            large: "button--large text-lg py-2.5 px-4",
+          },
+          m: {
+            0: "m-0",
+            1: "m-1",
+          },
+        },
+        compoundVariants: [
+          {
+            intent: "primary",
+            size: "medium",
+            class: "button--primary-medium uppercase",
+          },
+          {
+            intent: "warning",
+            disabled: false,
+            class: "button--warning-enabled text-gray-800",
+          },
+          {
+            intent: "warning",
+            disabled: true,
+            class: "button--warning-disabled text-black",
+          },
+        ],
+      });
+      const buttonWithoutBaseWithoutDefaultsWithClassNameString = cva({
+        variants: {
+          intent: {
+            primary:
+              "button--primary bg-blue-500 text-white border-transparent hover:bg-blue-600",
+            secondary:
+              "button--secondary bg-white text-gray-800 border-gray-400 hover:bg-gray-100",
+            warning:
+              "button--warning bg-yellow-500 border-transparent hover:bg-yellow-600",
+            danger:
+              "button--danger bg-red-500 text-white border-transparent hover:bg-red-600",
+          },
+          disabled: {
+            true: "button--disabled opacity-050 cursor-not-allowed",
+            false: "button--enabled cursor-pointer",
+          },
+          size: {
+            small: "button--small text-sm py-1 px-2",
+            medium: "button--medium text-base py-2 px-4",
+            large: "button--large text-lg py-2.5 px-4",
+          },
+          m: {
+            0: "m-0",
+            1: "m-1",
+          },
+        },
+        compoundVariants: [
+          {
+            intent: "primary",
+            size: "medium",
+            className: "button--primary-medium uppercase",
+          },
+          {
+            intent: "warning",
+            disabled: false,
+            className: "button--warning-enabled text-gray-800",
+          },
+          {
+            intent: "warning",
+            disabled: true,
+            className: "button--warning-disabled text-black",
+          },
+        ],
+      });
+
+      const buttonWithoutBaseWithoutDefaultsArray = cva({
+        variants: {
+          intent: {
+            primary: [
+              "button--primary",
+              "bg-blue-500",
+              "text-white",
+              "border-transparent",
+              "hover:bg-blue-600",
+            ],
+            secondary: [
+              "button--secondary",
+              "bg-white",
+              "text-gray-800",
+              "border-gray-400",
+              "hover:bg-gray-100",
+            ],
+            warning: [
+              "button--warning",
+              "bg-yellow-500",
+              "border-transparent",
+              "hover:bg-yellow-600",
+            ],
+            danger: [
+              "button--danger",
+              "bg-red-500",
+              "text-white",
+              "border-transparent",
+              "hover:bg-red-600",
+            ],
+          },
+          disabled: {
+            true: ["button--disabled", "opacity-050", "cursor-not-allowed"],
+            false: ["button--enabled", "cursor-pointer"],
+          },
+          size: {
+            small: ["button--small", "text-sm", "py-1", "px-2"],
+            medium: ["button--medium", "text-base", "py-2", "px-4"],
+            large: ["button--large", "text-lg", "py-2.5", "px-4"],
+          },
+          m: {
+            0: "m-0",
+            1: "m-1",
+          },
+        },
+        compoundVariants: [
+          {
+            intent: "primary",
+            size: "medium",
+            class: ["button--primary-medium", "uppercase"],
+          },
+          {
+            intent: "warning",
+            disabled: false,
+            class: ["button--warning-enabled", "text-gray-800"],
+          },
+          {
+            intent: "warning",
+            disabled: true,
+            class: ["button--warning-disabled", "text-black"],
+          },
+        ],
+      });
+      const buttonWithoutBaseWithoutDefaultsWithClassNameArray = cva({
+        variants: {
+          intent: {
+            primary: [
+              "button--primary",
+              "bg-blue-500",
+              "text-white",
+              "border-transparent",
+              "hover:bg-blue-600",
+            ],
+            secondary: [
+              "button--secondary",
+              "bg-white",
+              "text-gray-800",
+              "border-gray-400",
+              "hover:bg-gray-100",
+            ],
+            warning: [
+              "button--warning",
+              "bg-yellow-500",
+              "border-transparent",
+              "hover:bg-yellow-600",
+            ],
+            danger: [
+              "button--danger",
+              "bg-red-500",
+              "text-white",
+              "border-transparent",
+              "hover:bg-red-600",
+            ],
+          },
+          disabled: {
+            true: ["button--disabled", "opacity-050", "cursor-not-allowed"],
+            false: ["button--enabled", "cursor-pointer"],
+          },
+          size: {
+            small: ["button--small", "text-sm", "py-1", "px-2"],
+            medium: ["button--medium", "text-base", "py-2", "px-4"],
+            large: ["button--large", "text-lg", "py-2.5", "px-4"],
+          },
+          m: {
+            0: "m-0",
+            1: "m-1",
+          },
+        },
+        compoundVariants: [
+          {
+            intent: "primary",
+            size: "medium",
+            className: ["button--primary-medium", "uppercase"],
+          },
+          {
+            intent: "warning",
+            disabled: false,
+            className: ["button--warning-enabled", "text-gray-800"],
+          },
+          {
+            intent: "warning",
+            disabled: true,
+            className: ["button--warning-disabled", "text-black"],
+          },
+        ],
+      });
+
+      type ButtonWithoutDefaultsWithoutBaseProps =
+        | CVA.VariantProps<typeof buttonWithoutBaseWithoutDefaultsString>
+        | CVA.VariantProps<
+            typeof buttonWithoutBaseWithoutDefaultsWithClassNameString
+          >
+        | CVA.VariantProps<typeof buttonWithoutBaseWithoutDefaultsArray>
+        | CVA.VariantProps<
+            typeof buttonWithoutBaseWithoutDefaultsWithClassNameArray
+          >;
+
+      describe.each<[ButtonWithoutDefaultsWithoutBaseProps, string]>([
+        [
+          // @ts-expect-error
+          undefined,
+          "",
+        ],
+        [{}, ""],
+        [
+          {
+            aCheekyInvalidProp: "lol",
+          } as ButtonWithoutDefaultsWithoutBaseProps,
+          "",
+        ],
+        [
+          { intent: "secondary" },
+          "button--secondary bg-white text-gray-800 border-gray-400 hover:bg-gray-100",
+        ],
+        [{ size: "small" }, "button--small text-sm py-1 px-2"],
+        [{ disabled: true }, "button--disabled opacity-050 cursor-not-allowed"],
+        [
+          {
+            intent: "secondary",
+            size: "unset",
+          },
+          "button--secondary bg-white text-gray-800 border-gray-400 hover:bg-gray-100",
+        ],
+        [
+          { intent: "secondary", size: undefined },
+          "button--secondary bg-white text-gray-800 border-gray-400 hover:bg-gray-100",
+        ],
+        [
+          { intent: "danger", size: "medium" },
+          "button--danger bg-red-500 text-white border-transparent hover:bg-red-600 button--medium text-base py-2 px-4",
+        ],
+        [
+          { intent: "warning", size: "large" },
+          "button--warning bg-yellow-500 border-transparent hover:bg-yellow-600 button--large text-lg py-2.5 px-4",
+        ],
+        [
+          { intent: "warning", size: "large", disabled: true },
+          "button--warning bg-yellow-500 border-transparent hover:bg-yellow-600 button--disabled opacity-050 cursor-not-allowed button--large text-lg py-2.5 px-4 button--warning-disabled text-black",
+        ],
+        [
+          { intent: "primary", m: 0 },
+          "button--primary bg-blue-500 text-white border-transparent hover:bg-blue-600 m-0",
+        ],
+        [
+          { intent: "primary", m: 1 },
+          "button--primary bg-blue-500 text-white border-transparent hover:bg-blue-600 m-1",
+        ],
+        // !@TODO Add type "extractor" including class prop
+        [
+          {
+            intent: "primary",
+            m: 1,
+            class: "adhoc-class",
+          } as ButtonWithoutDefaultsWithoutBaseProps,
+          "button--primary bg-blue-500 text-white border-transparent hover:bg-blue-600 m-1 adhoc-class",
+        ],
+        [
+          {
+            intent: "primary",
+            m: 1,
+            className: "adhoc-classname",
+          } as ButtonWithoutDefaultsWithoutBaseProps,
+          "button--primary bg-blue-500 text-white border-transparent hover:bg-blue-600 m-1 adhoc-classname",
+        ],
+        // typings needed
+      ])("button(%o)", (options, expected) => {
+        test(`returns ${expected}`, () => {
+          expect(buttonWithoutBaseWithoutDefaultsString(options)).toBe(
+            expected
+          );
+          expect(
+            buttonWithoutBaseWithoutDefaultsWithClassNameString(options)
+          ).toBe(expected);
+          expect(buttonWithoutBaseWithoutDefaultsArray(options)).toBe(expected);
+          expect(
+            buttonWithoutBaseWithoutDefaultsWithClassNameArray(options)
+          ).toBe(expected);
+        });
+      });
+    });
+
+    describe("with defaults", () => {
+      const buttonWithoutBaseWithDefaultsString = cva({
+        base: "button font-semibold border rounded",
+        variants: {
+          intent: {
+            primary:
+              "button--primary bg-blue-500 text-white border-transparent hover:bg-blue-600",
+            secondary:
+              "button--secondary bg-white text-gray-800 border-gray-400 hover:bg-gray-100",
+            warning:
+              "button--warning bg-yellow-500 border-transparent hover:bg-yellow-600",
+            danger:
+              "button--danger bg-red-500 text-white border-transparent hover:bg-red-600",
+          },
+          disabled: {
+            true: "button--disabled opacity-050 cursor-not-allowed",
+            false: "button--enabled cursor-pointer",
+          },
+          size: {
+            small: "button--small text-sm py-1 px-2",
+            medium: "button--medium text-base py-2 px-4",
+            large: "button--large text-lg py-2.5 px-4",
+          },
+          m: {
+            0: "m-0",
+            1: "m-1",
+          },
+        },
+        compoundVariants: [
+          {
+            intent: "primary",
+            size: "medium",
+            class: "button--primary-medium uppercase",
+          },
+          {
+            intent: "warning",
+            disabled: false,
+            class: "button--warning-enabled text-gray-800",
+          },
+          {
+            intent: "warning",
+            disabled: true,
+            class: "button--warning-disabled text-black",
+          },
+          {
+            intent: ["warning", "danger"],
+            class: "button--warning-danger !border-red-500",
+          },
+          {
+            intent: ["warning", "danger"],
+            size: "medium",
+            class: "button--warning-danger-medium",
+          },
+        ],
+        defaultVariants: {
+          m: 0,
+          disabled: false,
+          intent: "primary",
+          size: "medium",
+        },
+      });
+      const buttonWithoutBaseWithDefaultsWithClassNameString = cva({
+        base: "button font-semibold border rounded",
+        variants: {
+          intent: {
+            primary:
+              "button--primary bg-blue-500 text-white border-transparent hover:bg-blue-600",
+            secondary:
+              "button--secondary bg-white text-gray-800 border-gray-400 hover:bg-gray-100",
+            warning:
+              "button--warning bg-yellow-500 border-transparent hover:bg-yellow-600",
+            danger:
+              "button--danger bg-red-500 text-white border-transparent hover:bg-red-600",
+          },
+          disabled: {
+            true: "button--disabled opacity-050 cursor-not-allowed",
+            false: "button--enabled cursor-pointer",
+          },
+          size: {
+            small: "button--small text-sm py-1 px-2",
+            medium: "button--medium text-base py-2 px-4",
+            large: "button--large text-lg py-2.5 px-4",
+          },
+          m: {
+            0: "m-0",
+            1: "m-1",
+          },
+        },
+        compoundVariants: [
+          {
+            intent: "primary",
+            size: "medium",
+            className: "button--primary-medium uppercase",
+          },
+          {
+            intent: "warning",
+            disabled: false,
+            className: "button--warning-enabled text-gray-800",
+          },
+          {
+            intent: "warning",
+            disabled: true,
+            className: "button--warning-disabled text-black",
+          },
+          {
+            intent: ["warning", "danger"],
+            className: "button--warning-danger !border-red-500",
+          },
+          {
+            intent: ["warning", "danger"],
+            size: "medium",
+            className: "button--warning-danger-medium",
+          },
+        ],
+        defaultVariants: {
+          m: 0,
+          disabled: false,
+          intent: "primary",
+          size: "medium",
+        },
+      });
+
+      const buttonWithoutBaseWithDefaultsArray = cva({
+        base: ["button", "font-semibold", "border", "rounded"],
+        variants: {
+          intent: {
+            primary: [
+              "button--primary",
+              "bg-blue-500",
+              "text-white",
+              "border-transparent",
+              "hover:bg-blue-600",
+            ],
+            secondary: [
+              "button--secondary",
+              "bg-white",
+              "text-gray-800",
+              "border-gray-400",
+              "hover:bg-gray-100",
+            ],
+            warning: [
+              "button--warning",
+              "bg-yellow-500",
+              "border-transparent",
+              "hover:bg-yellow-600",
+            ],
+            danger: [
+              "button--danger",
+              "bg-red-500",
+              "text-white",
+              "border-transparent",
+              "hover:bg-red-600",
+            ],
+          },
+          disabled: {
+            true: ["button--disabled", "opacity-050", "cursor-not-allowed"],
+            false: ["button--enabled", "cursor-pointer"],
+          },
+          size: {
+            small: ["button--small", "text-sm", "py-1", "px-2"],
+            medium: ["button--medium", "text-base", "py-2", "px-4"],
+            large: ["button--large", "text-lg", "py-2.5", "px-4"],
+          },
+          m: {
+            0: "m-0",
+            1: "m-1",
+          },
+        },
+        compoundVariants: [
+          {
+            intent: "primary",
+            size: "medium",
+            class: ["button--primary-medium", "uppercase"],
+          },
+          {
+            intent: "warning",
+            disabled: false,
+            class: ["button--warning-enabled", "text-gray-800"],
+          },
+          {
+            intent: "warning",
+            disabled: true,
+            class: ["button--warning-disabled", "text-black"],
+          },
+          {
+            intent: ["warning", "danger"],
+            class: ["button--warning-danger", "!border-red-500"],
+          },
+          {
+            intent: ["warning", "danger"],
+            size: "medium",
+            class: ["button--warning-danger-medium"],
+          },
+        ],
+        defaultVariants: {
+          m: 0,
+          disabled: false,
+          intent: "primary",
+          size: "medium",
+        },
+      });
+      const buttonWithoutBaseWithDefaultsWithClassNameArray = cva({
+        base: ["button", "font-semibold", "border", "rounded"],
+        variants: {
+          intent: {
+            primary: [
+              "button--primary",
+              "bg-blue-500",
+              "text-white",
+              "border-transparent",
+              "hover:bg-blue-600",
+            ],
+            secondary: [
+              "button--secondary",
+              "bg-white",
+              "text-gray-800",
+              "border-gray-400",
+              "hover:bg-gray-100",
+            ],
+            warning: [
+              "button--warning",
+              "bg-yellow-500",
+              "border-transparent",
+              "hover:bg-yellow-600",
+            ],
+            danger: [
+              "button--danger",
+              "bg-red-500",
+              "text-white",
+              "border-transparent",
+              "hover:bg-red-600",
+            ],
+          },
+          disabled: {
+            true: ["button--disabled", "opacity-050", "cursor-not-allowed"],
+            false: ["button--enabled", "cursor-pointer"],
+          },
+          size: {
+            small: ["button--small", "text-sm", "py-1", "px-2"],
+            medium: ["button--medium", "text-base", "py-2", "px-4"],
+            large: ["button--large", "text-lg", "py-2.5", "px-4"],
+          },
+          m: {
+            0: "m-0",
+            1: "m-1",
+          },
+        },
+        compoundVariants: [
+          {
+            intent: "primary",
+            size: "medium",
+            className: ["button--primary-medium", "uppercase"],
+          },
+          {
+            intent: "warning",
+            disabled: false,
+            className: ["button--warning-enabled", "text-gray-800"],
+          },
+          {
+            intent: "warning",
+            disabled: true,
+            className: ["button--warning-disabled", "text-black"],
+          },
+          {
+            intent: ["warning", "danger"],
+            className: "button--warning-danger !border-red-500",
+          },
+          {
+            intent: ["warning", "danger"],
+            size: "medium",
+            className: "button--warning-danger-medium",
+          },
+        ],
+        defaultVariants: {
+          m: 0,
+          disabled: false,
+          intent: "primary",
+          size: "medium",
+        },
+      });
+
+      type ButtonWithoutBaseWithDefaultsProps =
+        | CVA.VariantProps<typeof buttonWithoutBaseWithDefaultsString>
+        | CVA.VariantProps<
+            typeof buttonWithoutBaseWithDefaultsWithClassNameString
+          >
+        | CVA.VariantProps<typeof buttonWithoutBaseWithDefaultsArray>
+        | CVA.VariantProps<
+            typeof buttonWithoutBaseWithDefaultsWithClassNameArray
+          >;
+
+      describe.each<[ButtonWithoutBaseWithDefaultsProps, string]>([
+        [
+          // @ts-expect-error
+          undefined,
+          "button font-semibold border rounded button--primary bg-blue-500 text-white border-transparent hover:bg-blue-600 button--enabled cursor-pointer button--medium text-base py-2 px-4 m-0 button--primary-medium uppercase",
+        ],
+        [
+          {},
+          "button font-semibold border rounded button--primary bg-blue-500 text-white border-transparent hover:bg-blue-600 button--enabled cursor-pointer button--medium text-base py-2 px-4 m-0 button--primary-medium uppercase",
+        ],
+        [
+          {
+            aCheekyInvalidProp: "lol",
+          } as ButtonWithoutBaseWithDefaultsProps,
+          "button font-semibold border rounded button--primary bg-blue-500 text-white border-transparent hover:bg-blue-600 button--enabled cursor-pointer button--medium text-base py-2 px-4 m-0 button--primary-medium uppercase",
+        ],
+        [
+          { intent: "secondary" },
+          "button font-semibold border rounded button--secondary bg-white text-gray-800 border-gray-400 hover:bg-gray-100 button--enabled cursor-pointer button--medium text-base py-2 px-4 m-0",
+        ],
+
+        [
+          { size: "small" },
+          "button font-semibold border rounded button--primary bg-blue-500 text-white border-transparent hover:bg-blue-600 button--enabled cursor-pointer button--small text-sm py-1 px-2 m-0",
+        ],
+        [
+          { disabled: true },
+          "button font-semibold border rounded button--primary bg-blue-500 text-white border-transparent hover:bg-blue-600 button--disabled opacity-050 cursor-not-allowed button--medium text-base py-2 px-4 m-0 button--primary-medium uppercase",
+        ],
+        [
+          {
+            intent: "secondary",
+            size: "unset",
+          },
+          "button font-semibold border rounded button--secondary bg-white text-gray-800 border-gray-400 hover:bg-gray-100 button--enabled cursor-pointer m-0",
+        ],
+        [
+          { intent: "secondary", size: undefined },
+          "button font-semibold border rounded button--secondary bg-white text-gray-800 border-gray-400 hover:bg-gray-100 button--enabled cursor-pointer button--medium text-base py-2 px-4 m-0",
+        ],
+        [
+          { intent: "danger", size: "medium" },
+          "button font-semibold border rounded button--danger bg-red-500 text-white border-transparent hover:bg-red-600 button--enabled cursor-pointer button--medium text-base py-2 px-4 m-0 button--warning-danger !border-red-500 button--warning-danger-medium",
+        ],
+        [
+          { intent: "warning", size: "large" },
+          "button font-semibold border rounded button--warning bg-yellow-500 border-transparent hover:bg-yellow-600 button--enabled cursor-pointer button--large text-lg py-2.5 px-4 m-0 button--warning-enabled text-gray-800 button--warning-danger !border-red-500",
+        ],
+        [
+          { intent: "warning", size: "large", disabled: true },
+          "button font-semibold border rounded button--warning bg-yellow-500 border-transparent hover:bg-yellow-600 button--disabled opacity-050 cursor-not-allowed button--large text-lg py-2.5 px-4 m-0 button--warning-disabled text-black button--warning-danger !border-red-500",
+        ],
+        [
+          { intent: "primary", m: 0 },
+          "button font-semibold border rounded button--primary bg-blue-500 text-white border-transparent hover:bg-blue-600 button--enabled cursor-pointer button--medium text-base py-2 px-4 m-0 button--primary-medium uppercase",
+        ],
+        [
+          { intent: "primary", m: 1 },
+          "button font-semibold border rounded button--primary bg-blue-500 text-white border-transparent hover:bg-blue-600 button--enabled cursor-pointer button--medium text-base py-2 px-4 m-1 button--primary-medium uppercase",
+        ],
+        // !@TODO Add type "extractor" including class prop
+        [
+          {
+            intent: "primary",
+            m: 0,
+            class: "adhoc-class",
+          } as ButtonWithoutBaseWithDefaultsProps,
+          "button font-semibold border rounded button--primary bg-blue-500 text-white border-transparent hover:bg-blue-600 button--enabled cursor-pointer button--medium text-base py-2 px-4 m-0 button--primary-medium uppercase adhoc-class",
+        ],
+        [
+          {
+            intent: "primary",
+            m: 1,
+            className: "adhoc-classname",
+          } as ButtonWithoutBaseWithDefaultsProps,
+          "button font-semibold border rounded button--primary bg-blue-500 text-white border-transparent hover:bg-blue-600 button--enabled cursor-pointer button--medium text-base py-2 px-4 m-1 button--primary-medium uppercase adhoc-classname",
+        ],
+      ])("button(%o)", (options, expected) => {
+        test(`returns ${expected}`, () => {
+          expect(buttonWithoutBaseWithDefaultsString(options)).toBe(expected);
+          expect(
+            buttonWithoutBaseWithDefaultsWithClassNameString(options)
+          ).toBe(expected);
+          expect(buttonWithoutBaseWithDefaultsArray(options)).toBe(expected);
+          expect(buttonWithoutBaseWithDefaultsWithClassNameArray(options)).toBe(
+            expected
+          );
+        });
+      });
+    });
+  });
+
+  describe("with base", () => {
+    describe("without defaults", () => {
+      const buttonWithBaseWithoutDefaultsString = cva({
+        base: "button font-semibold border rounded",
+        variants: {
+          intent: {
+            primary:
+              "button--primary bg-blue-500 text-white border-transparent hover:bg-blue-600",
+            secondary:
+              "button--secondary bg-white text-gray-800 border-gray-400 hover:bg-gray-100",
+            warning:
+              "button--warning bg-yellow-500 border-transparent hover:bg-yellow-600",
+            danger:
+              "button--danger bg-red-500 text-white border-transparent hover:bg-red-600",
+          },
+          disabled: {
+            true: "button--disabled opacity-050 cursor-not-allowed",
+            false: "button--enabled cursor-pointer",
+          },
+          size: {
+            small: "button--small text-sm py-1 px-2",
+            medium: "button--medium text-base py-2 px-4",
+            large: "button--large text-lg py-2.5 px-4",
+          },
+        },
+        compoundVariants: [
+          {
+            intent: "primary",
+            size: "medium",
+            class: "button--primary-medium uppercase",
+          },
+          {
+            intent: "warning",
+            disabled: false,
+            class: "button--warning-enabled text-gray-800",
+          },
+          {
+            intent: "warning",
+            disabled: true,
+            class: "button--warning-disabled text-black",
+          },
+          {
+            intent: ["warning", "danger"],
+            class: "button--warning-danger !border-red-500",
+          },
+          {
+            intent: ["warning", "danger"],
+            size: "medium",
+            class: "button--warning-danger-medium",
+          },
+        ],
+      });
+      const buttonWithBaseWithoutDefaultsWithClassNameString = cva({
+        base: "button font-semibold border rounded",
+        variants: {
+          intent: {
+            primary:
+              "button--primary bg-blue-500 text-white border-transparent hover:bg-blue-600",
+            secondary:
+              "button--secondary bg-white text-gray-800 border-gray-400 hover:bg-gray-100",
+            warning:
+              "button--warning bg-yellow-500 border-transparent hover:bg-yellow-600",
+            danger:
+              "button--danger bg-red-500 text-white border-transparent hover:bg-red-600",
+          },
+          disabled: {
+            true: "button--disabled opacity-050 cursor-not-allowed",
+            false: "button--enabled cursor-pointer",
+          },
+          size: {
+            small: "button--small text-sm py-1 px-2",
+            medium: "button--medium text-base py-2 px-4",
+            large: "button--large text-lg py-2.5 px-4",
+          },
+        },
+        compoundVariants: [
+          {
+            intent: "primary",
+            size: "medium",
+            className: "button--primary-medium uppercase",
+          },
+          {
+            intent: "warning",
+            disabled: false,
+            className: "button--warning-enabled text-gray-800",
+          },
+          {
+            intent: "warning",
+            disabled: true,
+            className: "button--warning-disabled text-black",
+          },
+          {
+            intent: ["warning", "danger"],
+            className: "button--warning-danger !border-red-500",
+          },
+          {
+            intent: ["warning", "danger"],
+            size: "medium",
+            className: "button--warning-danger-medium",
+          },
+        ],
+      });
+
+      const buttonWithBaseWithoutDefaultsArray = cva({
+        base: ["button", "font-semibold", "border", "rounded"],
+        variants: {
+          intent: {
+            primary: [
+              "button--primary",
+              "bg-blue-500",
+              "text-white",
+              "border-transparent",
+              "hover:bg-blue-600",
+            ],
+            secondary: [
+              "button--secondary",
+              "bg-white",
+              "text-gray-800",
+              "border-gray-400",
+              "hover:bg-gray-100",
+            ],
+            warning: [
+              "button--warning",
+              "bg-yellow-500",
+              "border-transparent",
+              "hover:bg-yellow-600",
+            ],
+            danger: [
+              "button--danger",
+              "bg-red-500",
+              "text-white",
+              "border-transparent",
+              "hover:bg-red-600",
+            ],
+          },
+          disabled: {
+            true: ["button--disabled", "opacity-050", "cursor-not-allowed"],
+            false: ["button--enabled", "cursor-pointer"],
+          },
+          size: {
+            small: ["button--small", "text-sm", "py-1", "px-2"],
+            medium: ["button--medium", "text-base", "py-2", "px-4"],
+            large: ["button--large", "text-lg", "py-2.5", "px-4"],
+          },
+        },
+        compoundVariants: [
+          {
+            intent: "primary",
+            size: "medium",
+            class: ["button--primary-medium", "uppercase"],
+          },
+          {
+            intent: "warning",
+            disabled: false,
+            class: ["button--warning-enabled", "text-gray-800"],
+          },
+          {
+            intent: "warning",
+            disabled: true,
+            class: ["button--warning-disabled", "text-black"],
+          },
+          {
+            intent: ["warning", "danger"],
+            class: ["button--warning-danger", "!border-red-500"],
+          },
+          {
+            intent: ["warning", "danger"],
+            size: "medium",
+            class: ["button--warning-danger-medium"],
+          },
+        ],
+      });
+      const buttonWithBaseWithoutDefaultsWithClassNameArray = cva({
+        base: ["button", "font-semibold", "border", "rounded"],
+        variants: {
+          intent: {
+            primary: [
+              "button--primary",
+              "bg-blue-500",
+              "text-white",
+              "border-transparent",
+              "hover:bg-blue-600",
+            ],
+            secondary: [
+              "button--secondary",
+              "bg-white",
+              "text-gray-800",
+              "border-gray-400",
+              "hover:bg-gray-100",
+            ],
+            warning: [
+              "button--warning",
+              "bg-yellow-500",
+              "border-transparent",
+              "hover:bg-yellow-600",
+            ],
+            danger: [
+              "button--danger",
+              "bg-red-500",
+              "text-white",
+              "border-transparent",
+              "hover:bg-red-600",
+            ],
+          },
+          disabled: {
+            true: ["button--disabled", "opacity-050", "cursor-not-allowed"],
+            false: ["button--enabled", "cursor-pointer"],
+          },
+          size: {
+            small: ["button--small", "text-sm", "py-1", "px-2"],
+            medium: ["button--medium", "text-base", "py-2", "px-4"],
+            large: ["button--large", "text-lg", "py-2.5", "px-4"],
+          },
+        },
+        compoundVariants: [
+          {
+            intent: "primary",
+            size: "medium",
+            className: ["button--primary-medium", "uppercase"],
+          },
+          {
+            intent: "warning",
+            disabled: false,
+            className: ["button--warning-enabled", "text-gray-800"],
+          },
+          {
+            intent: "warning",
+            disabled: true,
+            className: ["button--warning-disabled", "text-black"],
+          },
+          {
+            intent: ["warning", "danger"],
+            className: ["button--warning-danger", "!border-red-500"],
+          },
+          {
+            intent: ["warning", "danger"],
+            size: "medium",
+            className: ["button--warning-danger-medium"],
+          },
+        ],
+      });
+
+      type ButtonWithBaseWithoutDefaultsProps =
+        | CVA.VariantProps<typeof buttonWithBaseWithoutDefaultsString>
+        | CVA.VariantProps<
+            typeof buttonWithBaseWithoutDefaultsWithClassNameString
+          >
+        | CVA.VariantProps<typeof buttonWithBaseWithoutDefaultsArray>
+        | CVA.VariantProps<
+            typeof buttonWithBaseWithoutDefaultsWithClassNameArray
+          >;
+
+      describe.each<[ButtonWithBaseWithoutDefaultsProps, string]>([
+        [
+          undefined as unknown as ButtonWithBaseWithoutDefaultsProps,
+          "button font-semibold border rounded",
+        ],
+        [{}, "button font-semibold border rounded"],
+        [
+          {
+            // @ts-expect-error
+            aCheekyInvalidProp: "lol",
+          },
+          "button font-semibold border rounded",
+        ],
+        [
+          { intent: "secondary" },
+          "button font-semibold border rounded button--secondary bg-white text-gray-800 border-gray-400 hover:bg-gray-100",
+        ],
+
+        [
+          { size: "small" },
+          "button font-semibold border rounded button--small text-sm py-1 px-2",
+        ],
+        [
+          { disabled: false },
+          "button font-semibold border rounded button--enabled cursor-pointer",
+        ],
+        [
+          { disabled: true },
+          "button font-semibold border rounded button--disabled opacity-050 cursor-not-allowed",
+        ],
+        [
+          { intent: "secondary", size: "unset" },
+          "button font-semibold border rounded button--secondary bg-white text-gray-800 border-gray-400 hover:bg-gray-100",
+        ],
+        [
+          { intent: "secondary", size: undefined },
+          "button font-semibold border rounded button--secondary bg-white text-gray-800 border-gray-400 hover:bg-gray-100",
+        ],
+        [
+          { intent: "danger", size: "medium" },
+          "button font-semibold border rounded button--danger bg-red-500 text-white border-transparent hover:bg-red-600 button--medium text-base py-2 px-4 button--warning-danger !border-red-500 button--warning-danger-medium",
+        ],
+        [
+          { intent: "warning", size: "large" },
+          "button font-semibold border rounded button--warning bg-yellow-500 border-transparent hover:bg-yellow-600 button--large text-lg py-2.5 px-4 button--warning-danger !border-red-500",
+        ],
+        [
+          { intent: "warning", size: "large", disabled: "unset" },
+          "button font-semibold border rounded button--warning bg-yellow-500 border-transparent hover:bg-yellow-600 button--large text-lg py-2.5 px-4 button--warning-danger !border-red-500",
+        ],
+        [
+          { intent: "warning", size: "large", disabled: true },
+          "button font-semibold border rounded button--warning bg-yellow-500 border-transparent hover:bg-yellow-600 button--disabled opacity-050 cursor-not-allowed button--large text-lg py-2.5 px-4 button--warning-disabled text-black button--warning-danger !border-red-500",
+        ],
+        [
+          { intent: "warning", size: "large", disabled: false },
+          "button font-semibold border rounded button--warning bg-yellow-500 border-transparent hover:bg-yellow-600 button--enabled cursor-pointer button--large text-lg py-2.5 px-4 button--warning-enabled text-gray-800 button--warning-danger !border-red-500",
+        ],
+        // !@TODO Add type "extractor" including class prop
+        [
+          {
+            intent: "primary",
+            class: "adhoc-class",
+          } as ButtonWithBaseWithoutDefaultsProps,
+          "button font-semibold border rounded button--primary bg-blue-500 text-white border-transparent hover:bg-blue-600 adhoc-class",
+        ],
+        [
+          {
+            intent: "primary",
+            className: "adhoc-className",
+          } as ButtonWithBaseWithoutDefaultsProps,
+          "button font-semibold border rounded button--primary bg-blue-500 text-white border-transparent hover:bg-blue-600 adhoc-className",
+        ],
+      ])("button(%o)", (options, expected) => {
+        test(`returns ${expected}`, () => {
+          expect(buttonWithBaseWithoutDefaultsString(options)).toBe(expected);
+          expect(
+            buttonWithBaseWithoutDefaultsWithClassNameString(options)
+          ).toBe(expected);
+          expect(buttonWithBaseWithoutDefaultsArray(options)).toBe(expected);
+          expect(buttonWithBaseWithoutDefaultsWithClassNameArray(options)).toBe(
+            expected
+          );
+        });
+      });
+    });
+
+    describe("with defaults", () => {
+      const buttonWithBaseWithDefaultsString = cva({
+        base: "button font-semibold border rounded",
+        variants: {
+          intent: {
+            primary:
+              "button--primary bg-blue-500 text-white border-transparent hover:bg-blue-600",
+            secondary:
+              "button--secondary bg-white text-gray-800 border-gray-400 hover:bg-gray-100",
+            warning:
+              "button--warning bg-yellow-500 border-transparent hover:bg-yellow-600",
+            danger:
+              "button--danger bg-red-500 text-white border-transparent hover:bg-red-600",
+          },
+          disabled: {
+            true: "button--disabled opacity-050 cursor-not-allowed",
+            false: "button--enabled cursor-pointer",
+          },
+          size: {
+            small: "button--small text-sm py-1 px-2",
+            medium: "button--medium text-base py-2 px-4",
+            large: "button--large text-lg py-2.5 px-4",
+          },
+        },
+        compoundVariants: [
+          {
+            intent: "primary",
+            size: "medium",
+            class: "button--primary-medium uppercase",
+          },
+          {
+            intent: "warning",
+            disabled: false,
+            class: "button--warning-enabled text-gray-800",
+          },
+          {
+            intent: "warning",
+            disabled: true,
+            class: "button--warning-disabled text-black",
+          },
+          {
+            intent: ["warning", "danger"],
+            class: "button--warning-danger !border-red-500",
+          },
+          {
+            intent: ["warning", "danger"],
+            size: "medium",
+            class: "button--warning-danger-medium",
+          },
+        ],
+        defaultVariants: {
+          disabled: false,
+          intent: "primary",
+          size: "medium",
+        },
+      });
+      const buttonWithBaseWithDefaultsWithClassNameString = cva({
+        base: "button font-semibold border rounded",
+        variants: {
+          intent: {
+            primary:
+              "button--primary bg-blue-500 text-white border-transparent hover:bg-blue-600",
+            secondary:
+              "button--secondary bg-white text-gray-800 border-gray-400 hover:bg-gray-100",
+            warning:
+              "button--warning bg-yellow-500 border-transparent hover:bg-yellow-600",
+            danger:
+              "button--danger bg-red-500 text-white border-transparent hover:bg-red-600",
+          },
+          disabled: {
+            true: "button--disabled opacity-050 cursor-not-allowed",
+            false: "button--enabled cursor-pointer",
+          },
+          size: {
+            small: "button--small text-sm py-1 px-2",
+            medium: "button--medium text-base py-2 px-4",
+            large: "button--large text-lg py-2.5 px-4",
+          },
+        },
+        compoundVariants: [
+          {
+            intent: "primary",
+            size: "medium",
+            className: "button--primary-medium uppercase",
+          },
+          {
+            intent: "warning",
+            disabled: false,
+            className: "button--warning-enabled text-gray-800",
+          },
+          {
+            intent: "warning",
+            disabled: true,
+            className: "button--warning-disabled text-black",
+          },
+          {
+            intent: ["warning", "danger"],
+            className: "button--warning-danger !border-red-500",
+          },
+          {
+            intent: ["warning", "danger"],
+            size: "medium",
+            className: "button--warning-danger-medium",
+          },
+        ],
+        defaultVariants: {
+          disabled: false,
+          intent: "primary",
+          size: "medium",
+        },
+      });
+
+      const buttonWithBaseWithDefaultsArray = cva({
+        base: ["button", "font-semibold", "border", "rounded"],
+        variants: {
+          intent: {
+            primary: [
+              "button--primary",
+              "bg-blue-500",
+              "text-white",
+              "border-transparent",
+              "hover:bg-blue-600",
+            ],
+            secondary: [
+              "button--secondary",
+              "bg-white",
+              "text-gray-800",
+              "border-gray-400",
+              "hover:bg-gray-100",
+            ],
+            warning: [
+              "button--warning",
+              "bg-yellow-500",
+              "border-transparent",
+              "hover:bg-yellow-600",
+            ],
+            danger: [
+              "button--danger",
+              "bg-red-500",
+              "text-white",
+              "border-transparent",
+              "hover:bg-red-600",
+            ],
+          },
+          disabled: {
+            true: ["button--disabled", "opacity-050", "cursor-not-allowed"],
+            false: ["button--enabled", "cursor-pointer"],
+          },
+          size: {
+            small: ["button--small", "text-sm", "py-1", "px-2"],
+            medium: ["button--medium", "text-base", "py-2", "px-4"],
+            large: ["button--large", "text-lg", "py-2.5", "px-4"],
+          },
+        },
+        compoundVariants: [
+          {
+            intent: "primary",
+            size: "medium",
+            class: ["button--primary-medium", "uppercase"],
+          },
+          {
+            intent: "warning",
+            disabled: false,
+            class: ["button--warning-enabled", "text-gray-800"],
+          },
+          {
+            intent: "warning",
+            disabled: true,
+            class: ["button--warning-disabled", "text-black"],
+          },
+          {
+            intent: ["warning", "danger"],
+            class: ["button--warning-danger", "!border-red-500"],
+          },
+          {
+            intent: ["warning", "danger"],
+            size: "medium",
+            class: ["button--warning-danger-medium"],
+          },
+        ],
+        defaultVariants: {
+          disabled: false,
+          intent: "primary",
+          size: "medium",
+        },
+      });
+      const buttonWithBaseWithDefaultsWithClassNameArray = cva({
+        base: ["button", "font-semibold", "border", "rounded"],
+        variants: {
+          intent: {
+            primary: [
+              "button--primary",
+              "bg-blue-500",
+              "text-white",
+              "border-transparent",
+              "hover:bg-blue-600",
+            ],
+            secondary: [
+              "button--secondary",
+              "bg-white",
+              "text-gray-800",
+              "border-gray-400",
+              "hover:bg-gray-100",
+            ],
+            warning: [
+              "button--warning",
+              "bg-yellow-500",
+              "border-transparent",
+              "hover:bg-yellow-600",
+            ],
+            danger: [
+              "button--danger",
+              "bg-red-500",
+              "text-white",
+              "border-transparent",
+              "hover:bg-red-600",
+            ],
+          },
+          disabled: {
+            true: ["button--disabled", "opacity-050", "cursor-not-allowed"],
+            false: ["button--enabled", "cursor-pointer"],
+          },
+          size: {
+            small: ["button--small", "text-sm", "py-1", "px-2"],
+            medium: ["button--medium", "text-base", "py-2", "px-4"],
+            large: ["button--large", "text-lg", "py-2.5", "px-4"],
+          },
+        },
+        compoundVariants: [
+          {
+            intent: "primary",
+            size: "medium",
+            className: ["button--primary-medium", "uppercase"],
+          },
+          {
+            intent: "warning",
+            disabled: false,
+            className: ["button--warning-enabled", "text-gray-800"],
+          },
+          {
+            intent: "warning",
+            disabled: true,
+            className: ["button--warning-disabled", "text-black"],
+          },
+          {
+            intent: ["warning", "danger"],
+            className: ["button--warning-danger", "!border-red-500"],
+          },
+          {
+            intent: ["warning", "danger"],
+            size: "medium",
+            className: ["button--warning-danger-medium"],
+          },
+        ],
+        defaultVariants: {
+          disabled: false,
+          intent: "primary",
+          size: "medium",
+        },
+      });
+
+      type ButtonWithBaseWithDefaultsProps =
+        | CVA.VariantProps<typeof buttonWithBaseWithDefaultsString>
+        | CVA.VariantProps<typeof buttonWithBaseWithDefaultsWithClassNameString>
+        | CVA.VariantProps<typeof buttonWithBaseWithDefaultsArray>
+        | CVA.VariantProps<typeof buttonWithBaseWithDefaultsWithClassNameArray>;
+
+      describe.each<[ButtonWithBaseWithDefaultsProps, string]>([
+        [
+          // @ts-expect-error
+          undefined,
+          "button font-semibold border rounded button--primary bg-blue-500 text-white border-transparent hover:bg-blue-600 button--enabled cursor-pointer button--medium text-base py-2 px-4 button--primary-medium uppercase",
+        ],
+        [
+          {},
+          "button font-semibold border rounded button--primary bg-blue-500 text-white border-transparent hover:bg-blue-600 button--enabled cursor-pointer button--medium text-base py-2 px-4 button--primary-medium uppercase",
+        ],
+        [
+          {
+            aCheekyInvalidProp: "lol",
+          } as ButtonWithBaseWithDefaultsProps,
+          "button font-semibold border rounded button--primary bg-blue-500 text-white border-transparent hover:bg-blue-600 button--enabled cursor-pointer button--medium text-base py-2 px-4 button--primary-medium uppercase",
+        ],
+        [
+          { intent: "secondary" },
+          "button font-semibold border rounded button--secondary bg-white text-gray-800 border-gray-400 hover:bg-gray-100 button--enabled cursor-pointer button--medium text-base py-2 px-4",
+        ],
+
+        [
+          { size: "small" },
+          "button font-semibold border rounded button--primary bg-blue-500 text-white border-transparent hover:bg-blue-600 button--enabled cursor-pointer button--small text-sm py-1 px-2",
+        ],
+        [
+          { disabled: "unset" },
+          "button font-semibold border rounded button--primary bg-blue-500 text-white border-transparent hover:bg-blue-600 button--medium text-base py-2 px-4 button--primary-medium uppercase",
+        ],
+        [
+          { disabled: false },
+          "button font-semibold border rounded button--primary bg-blue-500 text-white border-transparent hover:bg-blue-600 button--enabled cursor-pointer button--medium text-base py-2 px-4 button--primary-medium uppercase",
+        ],
+        [
+          { disabled: true },
+          "button font-semibold border rounded button--primary bg-blue-500 text-white border-transparent hover:bg-blue-600 button--disabled opacity-050 cursor-not-allowed button--medium text-base py-2 px-4 button--primary-medium uppercase",
+        ],
+        [
+          { intent: "secondary", size: "unset" },
+          "button font-semibold border rounded button--secondary bg-white text-gray-800 border-gray-400 hover:bg-gray-100 button--enabled cursor-pointer",
+        ],
+        [
+          { intent: "secondary", size: undefined },
+          "button font-semibold border rounded button--secondary bg-white text-gray-800 border-gray-400 hover:bg-gray-100 button--enabled cursor-pointer button--medium text-base py-2 px-4",
+        ],
+        [
+          { intent: "danger", size: "medium" },
+          "button font-semibold border rounded button--danger bg-red-500 text-white border-transparent hover:bg-red-600 button--enabled cursor-pointer button--medium text-base py-2 px-4 button--warning-danger !border-red-500 button--warning-danger-medium",
+        ],
+        [
+          { intent: "warning", size: "large" },
+          "button font-semibold border rounded button--warning bg-yellow-500 border-transparent hover:bg-yellow-600 button--enabled cursor-pointer button--large text-lg py-2.5 px-4 button--warning-enabled text-gray-800 button--warning-danger !border-red-500",
+        ],
+        [
+          {
+            intent: "warning",
+            size: "large",
+            disabled: "unset",
+          },
+          "button font-semibold border rounded button--warning bg-yellow-500 border-transparent hover:bg-yellow-600 button--large text-lg py-2.5 px-4 button--warning-danger !border-red-500",
+        ],
+        [
+          { intent: "warning", size: "large", disabled: true },
+          "button font-semibold border rounded button--warning bg-yellow-500 border-transparent hover:bg-yellow-600 button--disabled opacity-050 cursor-not-allowed button--large text-lg py-2.5 px-4 button--warning-disabled text-black button--warning-danger !border-red-500",
+        ],
+        [
+          { intent: "warning", size: "large", disabled: false },
+          "button font-semibold border rounded button--warning bg-yellow-500 border-transparent hover:bg-yellow-600 button--enabled cursor-pointer button--large text-lg py-2.5 px-4 button--warning-enabled text-gray-800 button--warning-danger !border-red-500",
+        ],
+        // !@TODO Add type "extractor" including class prop
+        [
+          {
+            intent: "primary",
+            class: "adhoc-class",
+          } as ButtonWithBaseWithDefaultsProps,
+          "button font-semibold border rounded button--primary bg-blue-500 text-white border-transparent hover:bg-blue-600 button--enabled cursor-pointer button--medium text-base py-2 px-4 button--primary-medium uppercase adhoc-class",
+        ],
+        [
+          {
+            intent: "primary",
+            className: "adhoc-classname",
+          } as ButtonWithBaseWithDefaultsProps,
+          "button font-semibold border rounded button--primary bg-blue-500 text-white border-transparent hover:bg-blue-600 button--enabled cursor-pointer button--medium text-base py-2 px-4 button--primary-medium uppercase adhoc-classname",
+        ],
+      ])("button(%o)", (options, expected) => {
+        test(`returns ${expected}`, () => {
+          expect(buttonWithBaseWithDefaultsString(options)).toBe(expected);
+          expect(buttonWithBaseWithDefaultsWithClassNameString(options)).toBe(
+            expected
+          );
+          expect(buttonWithBaseWithDefaultsArray(options)).toBe(expected);
+          expect(buttonWithBaseWithDefaultsWithClassNameArray(options)).toBe(
+            expected
+          );
+        });
+      });
+    });
+  });
+
+  describe("composing classes", () => {
+    type BoxProps = CVA.VariantProps<typeof box>;
+    const box = cva({
+      base: ["box", "box-border"],
+      variants: {
+        margin: { 0: "m-0", 2: "m-2", 4: "m-4", 8: "m-8" },
+        padding: { 0: "p-0", 2: "p-2", 4: "p-4", 8: "p-8" },
+      },
+      defaultVariants: {
+        margin: 0,
+        padding: 0,
+      },
+    });
+
+    type CardBaseProps = CVA.VariantProps<typeof cardBase>;
+    const cardBase = cva({
+      base: ["card", "border-solid", "border-slate-300", "rounded"],
+      variants: {
+        shadow: {
+          md: "drop-shadow-md",
+          lg: "drop-shadow-lg",
+          xl: "drop-shadow-xl",
+        },
+      },
+    });
+
+    interface CardProps extends BoxProps, CardBaseProps {}
+    const card = ({ margin, padding, shadow }: CardProps = {}) =>
+      cx(box({ margin, padding }), cardBase({ shadow }));
+
+    describe.each<[CardProps, string]>([
+      [
+        // @ts-expect-error
+        undefined,
+        "box box-border m-0 p-0 card border-solid border-slate-300 rounded",
+      ],
+      [{}, "box box-border m-0 p-0 card border-solid border-slate-300 rounded"],
+      [
+        { margin: 4 },
+        "box box-border m-4 p-0 card border-solid border-slate-300 rounded",
+      ],
+      [
+        { padding: 4 },
+        "box box-border m-0 p-4 card border-solid border-slate-300 rounded",
+      ],
+      [
+        { margin: 2, padding: 4 },
+        "box box-border m-2 p-4 card border-solid border-slate-300 rounded",
+      ],
+      [
+        { shadow: "md" },
+        "box box-border m-0 p-0 card border-solid border-slate-300 rounded drop-shadow-md",
+      ],
+    ])("card(%o)", (options, expected) => {
+      test(`returns ${expected}`, () => {
+        expect(card(options)).toBe(expected);
+      });
+    });
+  });
+});

--- a/packages/class-variance-authority/src/experimental/index.ts
+++ b/packages/class-variance-authority/src/experimental/index.ts
@@ -1,0 +1,120 @@
+import type {
+  ClassProp,
+  ClassValue,
+  OmitUndefined,
+  StringToBoolean,
+} from "./types";
+
+export type VariantProps<Component extends (...args: any) => any> = Omit<
+  OmitUndefined<Parameters<Component>[0]>,
+  "class" | "className"
+>;
+
+const falsyToString = <T extends unknown>(value: T) =>
+  typeof value === "boolean" ? `${value}` : value === 0 ? "0" : value;
+
+/* cx
+  ============================================ */
+
+export type CxOptions = ClassValue[];
+export type CxReturn = string;
+
+export const cx = <T extends CxOptions>(...classes: T): CxReturn =>
+  // @ts-ignore
+  classes.flat(Infinity).filter(Boolean).join(" ");
+
+/* cva
+  ============================================ */
+
+type ConfigSchema = Record<string, Record<string, ClassValue>>;
+
+type ConfigVariants<T extends ConfigSchema> = {
+  [Variant in keyof T]?: StringToBoolean<keyof T[Variant]> | "unset";
+};
+type ConfigVariantsMulti<T extends ConfigSchema> = {
+  [Variant in keyof T]?:
+    | StringToBoolean<keyof T[Variant]>
+    | StringToBoolean<keyof T[Variant]>[];
+};
+
+type Config<T> = T extends ConfigSchema
+  ? {
+      base?: ClassValue;
+      variants?: T;
+      defaultVariants?: ConfigVariants<T>;
+      compoundVariants?: (T extends ConfigSchema
+        ? (ConfigVariants<T> | ConfigVariantsMulti<T>) & ClassProp
+        : ClassProp)[];
+    }
+  : never;
+
+type Props<T> = T extends ConfigSchema
+  ? ConfigVariants<T> & ClassProp
+  : ClassProp;
+
+export const cva =
+  <T>(config: Config<T>) =>
+  (props?: Props<T>) => {
+    if (config?.variants == null)
+      return cx(config?.base, props?.class, props?.className);
+
+    const { variants, defaultVariants } = config;
+
+    const getVariantClassNames = Object.keys(variants).map(
+      (variant: keyof typeof variants) => {
+        const variantProp = props?.[variant as keyof typeof props];
+        const defaultVariantProp = defaultVariants?.[variant];
+
+        if (variantProp === "unset") return undefined;
+
+        const variantKey = (falsyToString(variantProp) ||
+          falsyToString(
+            defaultVariantProp
+          )) as keyof typeof variants[typeof variant];
+
+        return variants[variant][variantKey];
+      }
+    );
+
+    const propsWithoutUndefined =
+      props &&
+      Object.entries(props).reduce((acc, [key, value]) => {
+        if (value === undefined) {
+          return acc;
+        }
+
+        acc[key] = value;
+        return acc;
+      }, {} as Record<string, unknown>);
+
+    const getCompoundVariantClassNames = config?.compoundVariants?.reduce(
+      (
+        acc,
+        { class: cvClass, className: cvClassName, ...compoundVariantOptions }
+      ) =>
+        Object.entries(compoundVariantOptions).every(([key, value]) =>
+          Array.isArray(value)
+            ? value.includes(
+                {
+                  ...defaultVariants,
+                  ...propsWithoutUndefined,
+                }[key]
+              )
+            : {
+                ...defaultVariants,
+                ...propsWithoutUndefined,
+              }[key] === value
+        )
+          ? [...acc, cvClass, cvClassName]
+          : acc,
+      [] as ClassValue[]
+    );
+
+    return cx(
+      config?.base,
+      getVariantClassNames,
+      getCompoundVariantClassNames,
+      props?.class,
+      props?.className
+    );
+  };

--- a/packages/class-variance-authority/src/experimental/types.ts
+++ b/packages/class-variance-authority/src/experimental/types.ts
@@ -1,0 +1,15 @@
+export type ClassPropKey = "class" | "className";
+
+// Type 'string | null | undefined' is not assignable to type 'undefined' with 'exactOptionalPropertyTypes: true'. Consider adding 'undefined' to the type of the target.ts(2412)
+export type ClassValue = string | null | undefined | ClassValue[];
+
+export type ClassProp =
+  | {
+      class: ClassValue;
+      className?: never;
+    }
+  | { class?: never; className: ClassValue }
+  | { class?: never; className?: never };
+
+export type OmitUndefined<T> = T extends undefined ? never : T;
+export type StringToBoolean<T> = T extends "true" | "false" ? boolean : T;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: 5.3
+lockfileVersion: 5.4
 
 importers:
 
@@ -8,12 +8,16 @@ importers:
       lint-staged: 13.0.1
       npm-run-all: 4.1.5
       prettier: 2.6.2
+      prettier-plugin-packagejson: 2.4.2
+      prettier-plugin-tailwindcss: 0.2.2
       syncpack: 8.4.11
     devDependencies:
       husky: 8.0.1
       lint-staged: 13.0.1
       npm-run-all: 4.1.5
       prettier: 2.6.2
+      prettier-plugin-packagejson: 2.4.2_prettier@2.6.2
+      prettier-plugin-tailwindcss: 0.2.2_prettier@2.6.2
       syncpack: 8.4.11
 
   packages/class-variance-authority:
@@ -43,11 +47,11 @@ importers:
       '@types/react': 18.0.12
       '@types/react-dom': 18.0.5
       bundlesize: 0.18.1
-      jest: 28.1.1_174a6418721a92444f9d7dfb5aa73491
+      jest: 28.1.1_c5fgigdsdkjeit45px5vvjzuse
       npm-run-all: 4.1.5
       react: 18.1.0
       react-dom: 18.1.0_react@18.1.0
-      ts-node: 10.8.1_e77a828b1c9c90dd26fd0dc66bf30d8d
+      ts-node: 10.8.1_455ifcy4tsin2jx5bxdgx4ynru
       typescript: 4.7.3
 
 packages:
@@ -67,8 +71,8 @@ packages:
       '@babel/highlight': 7.18.6
     dev: true
 
-  /@babel/compat-data/7.20.10:
-    resolution: {integrity: sha512-sEnuDPpOJR/fcafHMjpcpGN5M2jbUGUHwmuWKM/YdPzeEDJg8bgmbcWQFUfE32MQjti1koACvoPVsDe8Uq+idg==}
+  /@babel/compat-data/7.20.14:
+    resolution: {integrity: sha512-0YpKHD6ImkWMEINCyDAD0HLLUH/lPCefG8ld9it8DJB2wnApraKuhgYTvTY1z7UFIfBTGy5LwncZ+5HWWGbhFw==}
     engines: {node: '>=6.9.0'}
     dev: true
 
@@ -78,13 +82,13 @@ packages:
     dependencies:
       '@ampproject/remapping': 2.2.0
       '@babel/code-frame': 7.18.6
-      '@babel/generator': 7.20.7
+      '@babel/generator': 7.20.14
       '@babel/helper-compilation-targets': 7.20.7_@babel+core@7.20.12
       '@babel/helper-module-transforms': 7.20.11
-      '@babel/helpers': 7.20.7
-      '@babel/parser': 7.20.7
+      '@babel/helpers': 7.20.13
+      '@babel/parser': 7.20.15
       '@babel/template': 7.20.7
-      '@babel/traverse': 7.20.12
+      '@babel/traverse': 7.20.13
       '@babel/types': 7.20.7
       convert-source-map: 1.9.0
       debug: 4.3.4
@@ -95,8 +99,8 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/generator/7.20.7:
-    resolution: {integrity: sha512-7wqMOJq8doJMZmP4ApXTzLxSr7+oO2jroJURrVEp6XShrQUObV8Tq/D0NCcoYg2uHqUrjzO0zwBjoYzelxK+sw==}
+  /@babel/generator/7.20.14:
+    resolution: {integrity: sha512-AEmuXHdcD3A52HHXxaTmYlb8q/xMEhoRP67B3T4Oq7lbmSoqroMZzjnGj3+i1io3pdnF8iBYVu4Ilj+c4hBxYg==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.20.7
@@ -110,10 +114,10 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/compat-data': 7.20.10
+      '@babel/compat-data': 7.20.14
       '@babel/core': 7.20.12
       '@babel/helper-validator-option': 7.18.6
-      browserslist: 4.21.4
+      browserslist: 4.21.5
       lru-cache: 5.1.1
       semver: 6.3.0
     dev: true
@@ -155,7 +159,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.18.6
       '@babel/helper-validator-identifier': 7.19.1
       '@babel/template': 7.20.7
-      '@babel/traverse': 7.20.12
+      '@babel/traverse': 7.20.13
       '@babel/types': 7.20.7
     transitivePeerDependencies:
       - supports-color
@@ -195,12 +199,12 @@ packages:
     engines: {node: '>=6.9.0'}
     dev: true
 
-  /@babel/helpers/7.20.7:
-    resolution: {integrity: sha512-PBPjs5BppzsGaxHQCDKnZ6Gd9s6xl8bBCluz3vEInLGRJmnZan4F6BYCeqtyXqkk4W5IlPmjK4JlOuZkpJ3xZA==}
+  /@babel/helpers/7.20.13:
+    resolution: {integrity: sha512-nzJ0DWCL3gB5RCXbUO3KIMMsBY2Eqbx8mBpKGE/02PgyRQFcPQLbkQ1vyy596mZLaP+dAfD+R4ckASzNVmW3jg==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/template': 7.20.7
-      '@babel/traverse': 7.20.12
+      '@babel/traverse': 7.20.13
       '@babel/types': 7.20.7
     transitivePeerDependencies:
       - supports-color
@@ -215,10 +219,12 @@ packages:
       js-tokens: 4.0.0
     dev: true
 
-  /@babel/parser/7.20.7:
-    resolution: {integrity: sha512-T3Z9oHybU+0vZlY9CiDSJQTD5ZapcW18ZctFMi0MOAl/4BjFF4ul7NVSARLdbGO5vDqy9eQiGTV0LtKfvCYvcg==}
+  /@babel/parser/7.20.15:
+    resolution: {integrity: sha512-DI4a1oZuf8wC+oAJA9RW6ga3Zbe8RZFt7kD9i4qAspz3I/yHet1VvC3DiSy/fsUvv5pvJuNPh0LPOdCcqinDPg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+    dependencies:
+      '@babel/types': 7.20.7
     dev: true
 
   /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.20.12:
@@ -345,21 +351,21 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/code-frame': 7.18.6
-      '@babel/parser': 7.20.7
+      '@babel/parser': 7.20.15
       '@babel/types': 7.20.7
     dev: true
 
-  /@babel/traverse/7.20.12:
-    resolution: {integrity: sha512-MsIbFN0u+raeja38qboyF8TIT7K0BFzz/Yd/77ta4MsUsmP2RAnidIlwq7d5HFQrH/OZJecGV6B71C4zAgpoSQ==}
+  /@babel/traverse/7.20.13:
+    resolution: {integrity: sha512-kMJXfF0T6DIS9E8cgdLCSAL+cuCK+YEZHWiLK0SXpTo8YRj5lpJu3CDNKiIBCne4m9hhTIqUg6SYTAI39tAiVQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/code-frame': 7.18.6
-      '@babel/generator': 7.20.7
+      '@babel/generator': 7.20.14
       '@babel/helper-environment-visitor': 7.18.9
       '@babel/helper-function-name': 7.19.0
       '@babel/helper-hoist-variables': 7.18.6
       '@babel/helper-split-export-declaration': 7.18.6
-      '@babel/parser': 7.20.7
+      '@babel/parser': 7.20.15
       '@babel/types': 7.20.7
       debug: 4.3.4
       globals: 11.12.0
@@ -436,7 +442,7 @@ packages:
       exit: 0.1.2
       graceful-fs: 4.2.10
       jest-changed-files: 28.1.3
-      jest-config: 28.1.3_174a6418721a92444f9d7dfb5aa73491
+      jest-config: 28.1.3_c5fgigdsdkjeit45px5vvjzuse
       jest-haste-map: 28.1.3
       jest-message-util: 28.1.3
       jest-regex-util: 28.0.2
@@ -631,7 +637,7 @@ packages:
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
       '@types/node': 18.11.18
-      '@types/yargs': 17.0.19
+      '@types/yargs': 17.0.22
       chalk: 4.1.2
     dev: true
 
@@ -643,7 +649,7 @@ packages:
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
       '@types/node': 18.11.18
-      '@types/yargs': 17.0.19
+      '@types/yargs': 17.0.22
       chalk: 4.1.2
     dev: true
 
@@ -711,6 +717,18 @@ packages:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.15.0
+    dev: true
+
+  /@pkgr/utils/2.3.1:
+    resolution: {integrity: sha512-wfzX8kc1PMyUILA+1Z/EqoE4UCXGy0iRGMhPwdfae1+f0OXlLqCk+By+aMzgJBzR9AzS4CDizioG6Ss1gvAFJw==}
+    engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+    dependencies:
+      cross-spawn: 7.0.3
+      is-glob: 4.0.3
+      open: 8.4.1
+      picocolors: 1.0.0
+      tiny-glob: 0.2.9
+      tslib: 2.5.0
     dev: true
 
   /@sinclair/typebox/0.24.51:
@@ -910,10 +928,10 @@ packages:
     resolution: {integrity: sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==}
     dev: true
 
-  /@types/babel__core/7.1.20:
-    resolution: {integrity: sha512-PVb6Bg2QuscZ30FvOU7z4guG6c926D9YRvOxEaelzndpMsvP+YM74Q/dAFASpg2l6+XLalxSGxcq/lrgYWZtyQ==}
+  /@types/babel__core/7.20.0:
+    resolution: {integrity: sha512-+n8dL/9GWblDO0iU6eZAwEIJVr5DWigtle+Q6HLOrh/pdbXOhOtqzq8VPPE2zvNJzSKY4vH/z3iT3tn0A3ypiQ==}
     dependencies:
-      '@babel/parser': 7.20.7
+      '@babel/parser': 7.20.15
       '@babel/types': 7.20.7
       '@types/babel__generator': 7.6.4
       '@types/babel__template': 7.4.1
@@ -929,7 +947,7 @@ packages:
   /@types/babel__template/7.4.1:
     resolution: {integrity: sha512-azBFKemX6kMg5Io+/rdGT0dkGreboUVR0Cdm3fz9QJWpaQGJRQXl7C+6hOTCZcMll7KFyEQpgbYI2lHdsS4U7g==}
     dependencies:
-      '@babel/parser': 7.20.7
+      '@babel/parser': 7.20.15
       '@babel/types': 7.20.7
     dev: true
 
@@ -1016,8 +1034,8 @@ packages:
       '@types/yargs-parser': 21.0.0
     dev: true
 
-  /@types/yargs/17.0.19:
-    resolution: {integrity: sha512-cAx3qamwaYX9R0fzOIZAlFpo4A+1uBVCxqpKz9D26uTF4srRXaGTTsikQmaotCtNdbhzyUH7ft6p9ktz9s6UNQ==}
+  /@types/yargs/17.0.22:
+    resolution: {integrity: sha512-pet5WJ9U8yPVRhkwuEIp5ktAeAqRZOq4UdAyWLWzxbtpyXnzbtLdKiXAjJzi/KLmPGS9wk86lUFWZFN6sISo4g==}
     dependencies:
       '@types/yargs-parser': 21.0.0
     dev: true
@@ -1027,8 +1045,8 @@ packages:
     engines: {node: '>=0.4.0'}
     dev: true
 
-  /acorn/8.8.1:
-    resolution: {integrity: sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==}
+  /acorn/8.8.2:
+    resolution: {integrity: sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
     dev: true
@@ -1154,7 +1172,7 @@ packages:
     dependencies:
       '@babel/core': 7.20.12
       '@jest/transform': 28.1.3
-      '@types/babel__core': 7.1.20
+      '@types/babel__core': 7.20.0
       babel-plugin-istanbul: 6.1.1
       babel-preset-jest: 28.1.3_@babel+core@7.20.12
       chalk: 4.1.2
@@ -1183,7 +1201,7 @@ packages:
     dependencies:
       '@babel/template': 7.20.7
       '@babel/types': 7.20.7
-      '@types/babel__core': 7.1.20
+      '@types/babel__core': 7.20.0
       '@types/babel__traverse': 7.18.3
     dev: true
 
@@ -1262,15 +1280,15 @@ packages:
       iltorb: 2.4.5
     dev: true
 
-  /browserslist/4.21.4:
-    resolution: {integrity: sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==}
+  /browserslist/4.21.5:
+    resolution: {integrity: sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
     dependencies:
-      caniuse-lite: 1.0.30001445
-      electron-to-chromium: 1.4.284
-      node-releases: 2.0.8
-      update-browserslist-db: 1.0.10_browserslist@4.21.4
+      caniuse-lite: 1.0.30001451
+      electron-to-chromium: 1.4.295
+      node-releases: 2.0.10
+      update-browserslist-db: 1.0.10_browserslist@4.21.5
     dev: true
 
   /bser/2.1.1:
@@ -1317,7 +1335,7 @@ packages:
     resolution: {integrity: sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==}
     dependencies:
       function-bind: 1.1.1
-      get-intrinsic: 1.1.3
+      get-intrinsic: 1.2.0
     dev: true
 
   /caller-callsite/2.0.0:
@@ -1354,8 +1372,8 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /caniuse-lite/1.0.30001445:
-    resolution: {integrity: sha512-8sdQIdMztYmzfTMO6KfLny878Ln9c2M0fc7EH60IjlP4Dc4PiCy7K2Vl3ITmWgOyPgVQKa5x+UP/KqFsxj4mBg==}
+  /caniuse-lite/1.0.30001451:
+    resolution: {integrity: sha512-XY7UbUpGRatZzoRft//5xOa69/1iGJRBlrieH6QYrkKLIFn3m7OVEJ81dSrKoy2BnKsdbX5cLrOispZNYo9v2w==}
     dev: true
 
   /chalk/2.1.0:
@@ -1594,13 +1612,18 @@ packages:
     engines: {node: '>=4.0.0'}
     dev: true
 
-  /deepmerge/4.2.2:
-    resolution: {integrity: sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==}
+  /deepmerge/4.3.0:
+    resolution: {integrity: sha512-z2wJZXrmeHdvYJp/Ux55wIjqo81G5Bp4c+oELTW+7ar6SogWHajt5a9gO3s3IDaGSAXjDk0vlQKN3rms8ab3og==}
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /define-properties/1.1.4:
-    resolution: {integrity: sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==}
+  /define-lazy-prop/2.0.0:
+    resolution: {integrity: sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /define-properties/1.2.0:
+    resolution: {integrity: sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==}
     engines: {node: '>= 0.4'}
     dependencies:
       has-property-descriptors: 1.0.0
@@ -1609,6 +1632,11 @@ packages:
 
   /delegates/1.0.0:
     resolution: {integrity: sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==}
+    dev: true
+
+  /detect-indent/7.0.1:
+    resolution: {integrity: sha512-Mc7QhQ8s+cLrnUfU/Ji94vG/r8M26m8f++vyres4ZoojaRDpZ1eSIh/EpzLNwlWuvzSZ3UbDFspjFvTDXe6e/g==}
+    engines: {node: '>=12.20'}
     dev: true
 
   /detect-libc/1.0.3:
@@ -1620,6 +1648,11 @@ packages:
   /detect-newline/3.1.0:
     resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
     engines: {node: '>=8'}
+    dev: true
+
+  /detect-newline/4.0.0:
+    resolution: {integrity: sha512-1aXUEPdfGdzVPFpzGJJNgq9o81bGg1s09uxTWsqBlo9PI332uyJRQq13+LK/UN4JfxJbFdCXonUFQ9R/p7yCtw==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dev: true
 
   /diff-sequences/27.5.1:
@@ -1637,6 +1670,13 @@ packages:
     engines: {node: '>=0.3.1'}
     dev: true
 
+  /dir-glob/3.0.1:
+    resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
+    engines: {node: '>=8'}
+    dependencies:
+      path-type: 4.0.0
+    dev: true
+
   /duplexer/0.1.2:
     resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
     dev: true
@@ -1645,8 +1685,8 @@ packages:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
     dev: true
 
-  /electron-to-chromium/1.4.284:
-    resolution: {integrity: sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==}
+  /electron-to-chromium/1.4.295:
+    resolution: {integrity: sha512-lEO94zqf1bDA3aepxwnWoHUjA8sZ+2owgcSZjYQy0+uOSEclJX0VieZC+r+wLpSxUHRd6gG32znTWmr+5iGzFw==}
     dev: true
 
   /emittery/0.10.2:
@@ -1684,7 +1724,7 @@ packages:
       es-to-primitive: 1.2.1
       function-bind: 1.1.1
       function.prototype.name: 1.1.5
-      get-intrinsic: 1.1.3
+      get-intrinsic: 1.2.0
       get-symbol-description: 1.0.0
       globalthis: 1.0.3
       gopd: 1.0.1
@@ -1692,7 +1732,7 @@ packages:
       has-property-descriptors: 1.0.0
       has-proto: 1.0.1
       has-symbols: 1.0.3
-      internal-slot: 1.0.4
+      internal-slot: 1.0.5
       is-array-buffer: 3.0.1
       is-callable: 1.2.7
       is-negative-zero: 2.0.2
@@ -1717,7 +1757,7 @@ packages:
     resolution: {integrity: sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==}
     engines: {node: '>= 0.4'}
     dependencies:
-      get-intrinsic: 1.1.3
+      get-intrinsic: 1.2.0
       has: 1.0.3
       has-tostringtag: 1.0.0
     dev: true
@@ -1903,7 +1943,7 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.1.4
+      define-properties: 1.2.0
       es-abstract: 1.21.1
       functions-have-names: 1.2.3
     dev: true
@@ -1935,8 +1975,8 @@ packages:
     engines: {node: 6.* || 8.* || >= 10.*}
     dev: true
 
-  /get-intrinsic/1.1.3:
-    resolution: {integrity: sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==}
+  /get-intrinsic/1.2.0:
+    resolution: {integrity: sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==}
     dependencies:
       function-bind: 1.1.1
       has: 1.0.3
@@ -1958,7 +1998,11 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      get-intrinsic: 1.1.3
+      get-intrinsic: 1.2.0
+    dev: true
+
+  /git-hooks-list/3.0.0:
+    resolution: {integrity: sha512-XDfdemBGJIMAsHHOONHQxEH5dX2kCpE6MGZ1IsNvBuDPBZM3p4EAwAC7ygMjn/1/x+BJX0TK1ara1Zrh7JCFdQ==}
     dev: true
 
   /github-build/1.2.3:
@@ -2011,13 +2055,32 @@ packages:
     resolution: {integrity: sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==}
     engines: {node: '>= 0.4'}
     dependencies:
-      define-properties: 1.1.4
+      define-properties: 1.2.0
+    dev: true
+
+  /globalyzer/0.1.0:
+    resolution: {integrity: sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==}
+    dev: true
+
+  /globby/13.1.3:
+    resolution: {integrity: sha512-8krCNHXvlCgHDpegPzleMq07yMYTO2sXKASmZmquEYWEmCx6J5UTRbp5RwMJkTJGtcQ44YpiUYUiN0b9mzy8Bw==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      dir-glob: 3.0.1
+      fast-glob: 3.2.12
+      ignore: 5.2.4
+      merge2: 1.4.1
+      slash: 4.0.0
+    dev: true
+
+  /globrex/0.1.2:
+    resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
     dev: true
 
   /gopd/1.0.1:
     resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
     dependencies:
-      get-intrinsic: 1.1.3
+      get-intrinsic: 1.2.0
     dev: true
 
   /graceful-fs/4.2.10:
@@ -2054,7 +2117,7 @@ packages:
   /has-property-descriptors/1.0.0:
     resolution: {integrity: sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==}
     dependencies:
-      get-intrinsic: 1.1.3
+      get-intrinsic: 1.2.0
     dev: true
 
   /has-proto/1.0.1:
@@ -2111,6 +2174,11 @@ packages:
 
   /ieee754/1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+    dev: true
+
+  /ignore/5.2.4:
+    resolution: {integrity: sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==}
+    engines: {node: '>= 4'}
     dev: true
 
   /iltorb/2.4.5:
@@ -2175,11 +2243,11 @@ packages:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
     dev: true
 
-  /internal-slot/1.0.4:
-    resolution: {integrity: sha512-tA8URYccNzMo94s5MQZgH8NB/XTa6HsOo0MLfXTKKEnHVVdegzaQoFZ7Jp44bdvLvY2waT5dc+j5ICEswhi7UQ==}
+  /internal-slot/1.0.5:
+    resolution: {integrity: sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==}
     engines: {node: '>= 0.4'}
     dependencies:
-      get-intrinsic: 1.1.3
+      get-intrinsic: 1.2.0
       has: 1.0.3
       side-channel: 1.0.4
     dev: true
@@ -2188,7 +2256,7 @@ packages:
     resolution: {integrity: sha512-ASfLknmY8Xa2XtB4wmbz13Wu202baeA18cJBCeCy0wXUHZF0IPyVEXqKEcd+t2fNSLLL1vC6k7lxZEojNbISXQ==}
     dependencies:
       call-bind: 1.0.2
-      get-intrinsic: 1.1.3
+      get-intrinsic: 1.2.0
       is-typed-array: 1.1.10
     dev: true
 
@@ -2231,6 +2299,12 @@ packages:
   /is-directory/0.3.1:
     resolution: {integrity: sha512-yVChGzahRFvbkscn2MlwGismPO12i9+znNruC5gVEntG3qu0xQMzsGg/JFbrsqDOHtHFPci+V5aP5T9I+yeKqw==}
     engines: {node: '>=0.10.0'}
+    dev: true
+
+  /is-docker/2.2.1:
+    resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==}
+    engines: {node: '>=8'}
+    hasBin: true
     dev: true
 
   /is-extglob/2.1.1:
@@ -2282,6 +2356,11 @@ packages:
   /is-number/7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
+    dev: true
+
+  /is-plain-obj/4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
     dev: true
 
   /is-regex/1.1.4:
@@ -2339,6 +2418,13 @@ packages:
       call-bind: 1.0.2
     dev: true
 
+  /is-wsl/2.2.0:
+    resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
+    engines: {node: '>=8'}
+    dependencies:
+      is-docker: 2.2.1
+    dev: true
+
   /isarray/1.0.0:
     resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
     dev: true
@@ -2357,7 +2443,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       '@babel/core': 7.20.12
-      '@babel/parser': 7.20.7
+      '@babel/parser': 7.20.15
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.0
       semver: 6.3.0
@@ -2428,7 +2514,7 @@ packages:
       - supports-color
     dev: true
 
-  /jest-cli/28.1.3_174a6418721a92444f9d7dfb5aa73491:
+  /jest-cli/28.1.3_c5fgigdsdkjeit45px5vvjzuse:
     resolution: {integrity: sha512-roY3kvrv57Azn1yPgdTebPAXvdR2xfezaKKYzVxZ6It/5NCxzJym6tUI5P1zkdWhfUYkxEI9uZWcQdaFLo8mJQ==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     hasBin: true
@@ -2445,7 +2531,7 @@ packages:
       exit: 0.1.2
       graceful-fs: 4.2.10
       import-local: 3.1.0
-      jest-config: 28.1.3_174a6418721a92444f9d7dfb5aa73491
+      jest-config: 28.1.3_c5fgigdsdkjeit45px5vvjzuse
       jest-util: 28.1.3
       jest-validate: 28.1.3
       prompts: 2.4.2
@@ -2456,7 +2542,7 @@ packages:
       - ts-node
     dev: true
 
-  /jest-config/28.1.3_174a6418721a92444f9d7dfb5aa73491:
+  /jest-config/28.1.3_c5fgigdsdkjeit45px5vvjzuse:
     resolution: {integrity: sha512-MG3INjByJ0J4AsNBm7T3hsuxKQqFIiRo/AUqb1q9LRKI5UU6Aar9JHbr9Ivn1TVwfUD9KirRoM/T6u8XlcQPHQ==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     peerDependencies:
@@ -2475,7 +2561,7 @@ packages:
       babel-jest: 28.1.3_@babel+core@7.20.12
       chalk: 4.1.2
       ci-info: 3.7.1
-      deepmerge: 4.2.2
+      deepmerge: 4.3.0
       glob: 7.2.3
       graceful-fs: 4.2.10
       jest-circus: 28.1.3
@@ -2491,7 +2577,7 @@ packages:
       pretty-format: 28.1.3
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.8.1_e77a828b1c9c90dd26fd0dc66bf30d8d
+      ts-node: 10.8.1_455ifcy4tsin2jx5bxdgx4ynru
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2732,9 +2818,9 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
       '@babel/core': 7.20.12
-      '@babel/generator': 7.20.7
+      '@babel/generator': 7.20.14
       '@babel/plugin-syntax-typescript': 7.20.0_@babel+core@7.20.12
-      '@babel/traverse': 7.20.12
+      '@babel/traverse': 7.20.13
       '@babel/types': 7.20.7
       '@jest/expect-utils': 28.1.3
       '@jest/transform': 28.1.3
@@ -2805,7 +2891,7 @@ packages:
       supports-color: 8.1.1
     dev: true
 
-  /jest/28.1.1_174a6418721a92444f9d7dfb5aa73491:
+  /jest/28.1.1_c5fgigdsdkjeit45px5vvjzuse:
     resolution: {integrity: sha512-qw9YHBnjt6TCbIDMPMpJZqf9E12rh6869iZaN08/vpOGgHJSAaLLUn6H8W3IAEuy34Ls3rct064mZLETkxJ2XA==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     hasBin: true
@@ -2816,9 +2902,9 @@ packages:
         optional: true
     dependencies:
       '@jest/core': 28.1.3_ts-node@10.8.1
-      '@jest/types': 28.1.3
+      '@jest/types': 28.1.1
       import-local: 3.1.0
-      jest-cli: 28.1.3_174a6418721a92444f9d7dfb5aa73491
+      jest-cli: 28.1.3_c5fgigdsdkjeit45px5vvjzuse
     transitivePeerDependencies:
       - '@types/node'
       - supports-color
@@ -3047,8 +3133,8 @@ packages:
       brace-expansion: 2.0.1
     dev: true
 
-  /minimist/1.2.7:
-    resolution: {integrity: sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==}
+  /minimist/1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
     dev: true
 
   /mkdirp-classic/0.5.3:
@@ -3085,8 +3171,8 @@ packages:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
     dev: true
 
-  /node-releases/2.0.8:
-    resolution: {integrity: sha512-dFSmB8fFHEH/s81Xi+Y/15DQY6VHW81nXRj86EMSL3lmuTmK1e+aT4wrFCkTbm+gSwkw4KpX+rT/pMM2c1mF+A==}
+  /node-releases/2.0.10:
+    resolution: {integrity: sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w==}
     dev: true
 
   /noop-logger/0.1.1:
@@ -3119,7 +3205,7 @@ packages:
       minimatch: 3.1.2
       pidtree: 0.3.1
       read-pkg: 3.0.0
-      shell-quote: 1.7.4
+      shell-quote: 1.8.0
       string.prototype.padend: 3.1.4
     dev: true
 
@@ -3170,7 +3256,7 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.1.4
+      define-properties: 1.2.0
       has-symbols: 1.0.3
       object-keys: 1.1.1
     dev: true
@@ -3193,6 +3279,15 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       mimic-fn: 4.0.0
+    dev: true
+
+  /open/8.4.1:
+    resolution: {integrity: sha512-/4b7qZNhv6Uhd7jjnREh1NjnPxlTq+XNWPG88Ydkj5AILcA5m3ajvcg57pB24EQjKv0dK62XnDqk9c/hkIG5Kg==}
+    engines: {node: '>=12'}
+    dependencies:
+      define-lazy-prop: 2.0.0
+      is-docker: 2.2.1
+      is-wsl: 2.2.0
     dev: true
 
   /p-limit/2.3.0:
@@ -3340,7 +3435,7 @@ packages:
       detect-libc: 1.0.3
       expand-template: 2.0.3
       github-from-package: 0.0.0
-      minimist: 1.2.7
+      minimist: 1.2.8
       mkdirp-classic: 0.5.3
       napi-build-utils: 1.0.2
       node-abi: 2.30.1
@@ -3352,6 +3447,71 @@ packages:
       tar-fs: 2.1.1
       tunnel-agent: 0.6.0
       which-pm-runs: 1.1.0
+    dev: true
+
+  /prettier-plugin-packagejson/2.4.2_prettier@2.6.2:
+    resolution: {integrity: sha512-Y/sW29qq0FhEQRA+85K98VOlMW7/Wicrm0Tm2j/EZ+Eh7F6jVUpGVv7WIMku+WsaEab/PyxaA5ckmTd3E0seNg==}
+    peerDependencies:
+      prettier: '>= 1.16.0'
+    peerDependenciesMeta:
+      prettier:
+        optional: true
+    dependencies:
+      prettier: 2.6.2
+      sort-package-json: 2.2.0
+      synckit: 0.8.5
+    dev: true
+
+  /prettier-plugin-tailwindcss/0.2.2_prettier@2.6.2:
+    resolution: {integrity: sha512-5RjUbWRe305pUpc48MosoIp6uxZvZxrM6GyOgsbGLTce+ehePKNm7ziW2dLG2air9aXbGuXlHVSQQw4Lbosq3w==}
+    engines: {node: '>=12.17.0'}
+    peerDependencies:
+      '@prettier/plugin-php': '*'
+      '@prettier/plugin-pug': '*'
+      '@shopify/prettier-plugin-liquid': '*'
+      '@shufo/prettier-plugin-blade': '*'
+      '@trivago/prettier-plugin-sort-imports': '*'
+      prettier: '>=2.2.0'
+      prettier-plugin-astro: '*'
+      prettier-plugin-css-order: '*'
+      prettier-plugin-import-sort: '*'
+      prettier-plugin-jsdoc: '*'
+      prettier-plugin-organize-attributes: '*'
+      prettier-plugin-organize-imports: '*'
+      prettier-plugin-style-order: '*'
+      prettier-plugin-svelte: '*'
+      prettier-plugin-twig-melody: '*'
+    peerDependenciesMeta:
+      '@prettier/plugin-php':
+        optional: true
+      '@prettier/plugin-pug':
+        optional: true
+      '@shopify/prettier-plugin-liquid':
+        optional: true
+      '@shufo/prettier-plugin-blade':
+        optional: true
+      '@trivago/prettier-plugin-sort-imports':
+        optional: true
+      prettier-plugin-astro:
+        optional: true
+      prettier-plugin-css-order:
+        optional: true
+      prettier-plugin-import-sort:
+        optional: true
+      prettier-plugin-jsdoc:
+        optional: true
+      prettier-plugin-organize-attributes:
+        optional: true
+      prettier-plugin-organize-imports:
+        optional: true
+      prettier-plugin-style-order:
+        optional: true
+      prettier-plugin-svelte:
+        optional: true
+      prettier-plugin-twig-melody:
+        optional: true
+    dependencies:
+      prettier: 2.6.2
     dev: true
 
   /prettier/2.6.2:
@@ -3414,7 +3574,7 @@ packages:
     dependencies:
       deep-extend: 0.6.0
       ini: 1.3.8
-      minimist: 1.2.7
+      minimist: 1.2.8
       strip-json-comments: 2.0.1
     dev: true
 
@@ -3486,7 +3646,7 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.1.4
+      define-properties: 1.2.0
       functions-have-names: 1.2.3
     dev: true
 
@@ -3564,7 +3724,7 @@ packages:
   /rxjs/7.8.0:
     resolution: {integrity: sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==}
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: true
 
   /safe-buffer/5.1.2:
@@ -3579,7 +3739,7 @@ packages:
     resolution: {integrity: sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==}
     dependencies:
       call-bind: 1.0.2
-      get-intrinsic: 1.1.3
+      get-intrinsic: 1.2.0
       is-regex: 1.1.4
     dev: true
 
@@ -3635,15 +3795,15 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /shell-quote/1.7.4:
-    resolution: {integrity: sha512-8o/QEhSSRb1a5i7TFR0iM4G16Z0vYB2OQVs4G3aAFXjn3T6yEx8AZxy1PgDF7I00LZHYA3WxaSYIf5e5sAX8Rw==}
+  /shell-quote/1.8.0:
+    resolution: {integrity: sha512-QHsz8GgQIGKlRi24yFc6a6lN69Idnx634w49ay6+jA5yFh7a1UY+4Rp6HPx/L/1zcEDPEij8cIsiqR6bQsE5VQ==}
     dev: true
 
   /side-channel/1.0.4:
     resolution: {integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==}
     dependencies:
       call-bind: 1.0.2
-      get-intrinsic: 1.1.3
+      get-intrinsic: 1.2.0
       object-inspect: 1.12.3
     dev: true
 
@@ -3672,6 +3832,11 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /slash/4.0.0:
+    resolution: {integrity: sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==}
+    engines: {node: '>=12'}
+    dev: true
+
   /slice-ansi/3.0.0:
     resolution: {integrity: sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==}
     engines: {node: '>=8'}
@@ -3696,6 +3861,22 @@ packages:
     dependencies:
       ansi-styles: 6.2.1
       is-fullwidth-code-point: 4.0.0
+    dev: true
+
+  /sort-object-keys/1.1.3:
+    resolution: {integrity: sha512-855pvK+VkU7PaKYPc+Jjnmt4EzejQHyhhF33q31qG8x7maDzkeFhAAThdCYay11CISO+qAMwjOBP+fPZe0IPyg==}
+    dev: true
+
+  /sort-package-json/2.2.0:
+    resolution: {integrity: sha512-ux712xsrPqkW+0b51GdmC8QTvImM3wsdip9mNVSQTY9ZV3/1eTAK6jIcQ8Vz9kfN1WHL4wv/pLn89mrqeyQu6A==}
+    hasBin: true
+    dependencies:
+      detect-indent: 7.0.1
+      detect-newline: 4.0.0
+      git-hooks-list: 3.0.0
+      globby: 13.1.3
+      is-plain-obj: 4.1.0
+      sort-object-keys: 1.1.3
     dev: true
 
   /source-map-support/0.5.13:
@@ -3793,7 +3974,7 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.1.4
+      define-properties: 1.2.0
       es-abstract: 1.21.1
     dev: true
 
@@ -3801,7 +3982,7 @@ packages:
     resolution: {integrity: sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.1.4
+      define-properties: 1.2.0
       es-abstract: 1.21.1
     dev: true
 
@@ -3809,7 +3990,7 @@ packages:
     resolution: {integrity: sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.1.4
+      define-properties: 1.2.0
       es-abstract: 1.21.1
     dev: true
 
@@ -3917,6 +4098,14 @@ packages:
     engines: {node: '>= 0.4'}
     dev: true
 
+  /synckit/0.8.5:
+    resolution: {integrity: sha512-L1dapNV6vu2s/4Sputv8xGsCdAVlb5nRDMFU/E27D44l5U6cw1g0dGd45uLc+OXjNMmF4ntiMdCimzcjFKQI8Q==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    dependencies:
+      '@pkgr/utils': 2.3.1
+      tslib: 2.5.0
+    dev: true
+
   /syncpack/8.4.11:
     resolution: {integrity: sha512-qYhkDvPr0goemEqykGaUKF4TD9sRlPQXNy0wn60SXsatAVaZPrNn/nFtfYBLGBp4gNlrpVzixnzBOTihQZxhmg==}
     engines: {node: '>=10'}
@@ -3975,6 +4164,13 @@ packages:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
     dev: true
 
+  /tiny-glob/0.2.9:
+    resolution: {integrity: sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==}
+    dependencies:
+      globalyzer: 0.1.0
+      globrex: 0.1.2
+    dev: true
+
   /tmpl/1.0.5:
     resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
     dev: true
@@ -3991,7 +4187,7 @@ packages:
       is-number: 7.0.0
     dev: true
 
-  /ts-node/10.8.1_e77a828b1c9c90dd26fd0dc66bf30d8d:
+  /ts-node/10.8.1_455ifcy4tsin2jx5bxdgx4ynru:
     resolution: {integrity: sha512-Wwsnao4DQoJsN034wePSg5nZiw4YKXf56mPIAeD6wVmiv+RytNSWqc2f3fKvcUoV+Yn2+yocD71VOfQHbmVX4g==}
     hasBin: true
     peerDependencies:
@@ -4012,7 +4208,7 @@ packages:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.3
       '@types/node': 18.11.18
-      acorn: 8.8.1
+      acorn: 8.8.2
       acorn-walk: 8.2.0
       arg: 4.1.3
       create-require: 1.1.1
@@ -4023,8 +4219,8 @@ packages:
       yn: 3.1.1
     dev: true
 
-  /tslib/2.4.1:
-    resolution: {integrity: sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==}
+  /tslib/2.5.0:
+    resolution: {integrity: sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==}
     dev: true
 
   /tunnel-agent/0.6.0:
@@ -4071,13 +4267,13 @@ packages:
     engines: {node: '>= 10.0.0'}
     dev: true
 
-  /update-browserslist-db/1.0.10_browserslist@4.21.4:
+  /update-browserslist-db/1.0.10_browserslist@4.21.5:
     resolution: {integrity: sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==}
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
     dependencies:
-      browserslist: 4.21.4
+      browserslist: 4.21.5
       escalade: 3.1.1
       picocolors: 1.0.0
     dev: true
@@ -4157,7 +4353,7 @@ packages:
   /wide-align/1.1.5:
     resolution: {integrity: sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==}
     dependencies:
-      string-width: 4.2.3
+      string-width: 1.0.2
     dev: true
 
   /wrap-ansi/6.2.0:


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Introduces the `/experimental` export to develop and test `class-variance-authority@1.0.0`, whilst preserving the current stable API

> **Warning**
> Changes in `/experimental` are not protected by semver

Changes available under `/experimental`

1. **Single parameter for `cva()`**
  Introduces a new `base` key instead of using the first parameter 
2. **Special keyword `"unset"` to disable a variant entirely** (instead of the current behaviour: `null`)
  A future PR will allow this to be enabled/disabled

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md).
- [ ] Follow the [Style Guide](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md#style-guide).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
