### PR TITLE
Fix Tailwind IntelliSense instructions for Neovim

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ You can enable autocompletion inside `cva` using the steps below:
        tailwindCSS = {
          experimental = {
            classRegex = {
-             "cva\\(([^)]*)\\)",
-             "[\"'`]([^\"'`]*).*?[\"'`]",
+             { "cva\\(([^)]*)\\)",
+               "[\"'`]([^\"'`]*).*?[\"'`]" },
            },
          },
        },


### PR DESCRIPTION
### Description

The existing docs were making tailwind consider the _whole_ `cva` call a single class list, resulting in warnings from the Tailwind LSP about duplicate and conflicting classes.


### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md).
- [x] Follow the [Style Guide](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md#style-guide).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
