### PR TITLE
docs: fix broken vanilla-extract link

### DIFF
--- a/docs/pages/docs/index.mdx
+++ b/docs/pages/docs/index.mdx
@@ -5,7 +5,7 @@
 
 # Class Variance Authority
 
-CSS-in-TS libraries such as [Stitches](https://stitches.dev/docs/variants) and [Vanilla Extract](https://vanilla-extract.style/documentation/) are **fantastic** options for building type-safe UI components; taking away all the worries of class names and StyleSheet composition.
+CSS-in-TS libraries such as [Stitches](https://stitches.dev/docs/variants) and [Vanilla Extract](https://vanilla-extract.style/documentation/api/style-variants/) are **fantastic** options for building type-safe UI components; taking away all the worries of class names and StyleSheet composition.
 
 …but CSS-in-TS (or CSS-in-JS) isn't for everyone.
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This PR fixes a broken link to vanilla-extract on the cva home page.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

I noticed that the cva docs link to the variant page of the [stitches](https://stitches.dev/docs/variants) website, so I did the same for [vanilla-extract](https://vanilla-extract.style/documentation/api/style-variants/). It also seemed appropriate, given the spirit of this project.

---

### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md).
- [x] Follow the [Style Guide](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md#style-guide).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
