### PR TITLE
add types to exports field in order to support `moduleResolution: bundler`

### DIFF
--- a/packages/class-variance-authority/package.json
+++ b/packages/class-variance-authority/package.json
@@ -21,7 +21,8 @@
   "author": "Joe Bell (https://joebell.co.uk)",
   "exports": {
     "import": "./dist/index.mjs",
-    "require": "./dist/index.js"
+    "require": "./dist/index.js",
+    "types": "./dist/index.d.ts"
   },
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/cva/package.json
+++ b/packages/cva/package.json
@@ -21,7 +21,8 @@
   "author": "Joe Bell (https://joebell.co.uk)",
   "exports": {
     "import": "./dist/index.mjs",
-    "require": "./dist/index.js"
+    "require": "./dist/index.js",
+    "types": "./dist/index.d.ts"
   },
   "main": "dist/index.js",
   "module": "dist/index.mjs",


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

When using TypeScript's new `moduleResolution: bundler` option, TS can't find the declaration file (`Could not find a declaration file for module 'class-variance-authority'`). By adding the types path to the `exports` field inside package.json, this works again.

### Additional context

Similar PR with additional info: https://github.com/ikenfin/vite-plugin-sentry/pull/252

### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md).
- [x] Follow the [Style Guide](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md#style-guide).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
