### PR TITLE
feat: support extending cva with custom cx

### DIFF
--- a/docs/pages/docs/api-reference.mdx
+++ b/docs/pages/docs/api-reference.mdx
@@ -36,3 +36,22 @@ const className = cx(classes);
 ### Returns
 
 `string`
+
+
+## `config`
+
+Builds a custom `cva` instance which extends/replaces the default `cx` functionality
+
+```ts
+const cva = config({
+  cx: (...inputs: CxOptions) => customCx(inputs)
+});
+```
+
+### Parameters
+
+- `cx`: a function that acts as CL ([see `clsx` usage](https://github.com/lukeed/clsx))
+
+### Returns
+
+A `cva` instance

--- a/docs/pages/docs/installation.mdx
+++ b/docs/pages/docs/installation.mdx
@@ -134,3 +134,34 @@ export const button = (variants: ButtonVariants) =>
 ```
 
 </details>
+
+<details>
+
+<summary>Example extending cva with tailwind-merge</summary>
+
+```ts
+import { config, cx, type CxOptions, type VariantProps } from "class-variance-authority";
+import { twMerge } from "tailwind-merge";
+
+export const cva = config({
+  cx: (...inputs: CxOptions) => twMerge(cx(inputs)),
+});
+
+const buttonVariants = cva(["your", "base", "classes"], {
+  variants: {
+    intent: {
+      primary: ["your", "primary", "classes"],
+    },
+  },
+  defaultVariants: {
+    intent: "primary",
+  },
+});
+
+export interface ButtonVariants extends VariantProps<typeof buttonVariants> {}
+
+export const button = (variants: ButtonVariants) => buttonVariants(variants);
+
+```
+
+</details>

--- a/packages/class-variance-authority/src/index.ts
+++ b/packages/class-variance-authority/src/index.ts
@@ -52,7 +52,12 @@ type Props<T> = T extends ConfigSchema
   ? ConfigVariants<T> & ClassProp
   : ClassProp;
 
-export const cva =
+type ConfigWrapperProps = {
+  cx: (...inputs: CxOptions) => CxReturn;
+};
+
+export const config =
+  ({ cx }: ConfigWrapperProps) =>
   <T>(base?: ClassValue, config?: Config<T>) =>
   (props?: Props<T>) => {
     if (config?.variants == null)
@@ -118,3 +123,5 @@ export const cva =
       props?.className
     );
   };
+
+export const cva = config({ cx });

--- a/packages/cva/src/index.ts
+++ b/packages/cva/src/index.ts
@@ -62,7 +62,12 @@ type Props<V> = V extends VariantShape
   ? VariantSchema<V> & ClassProp
   : ClassProp;
 
-export const cva =
+type ConfigWrapperProps = {
+  cx: (...inputs: CxOptions) => CxReturn;
+};
+
+export const config =
+  ({ cx }: ConfigWrapperProps) =>
   <
     _ extends "cva's generic parameters are restricted to internal use only.",
     V
@@ -85,7 +90,7 @@ export const cva =
         const variantKey = (falsyToString(variantProp) ||
           falsyToString(
             defaultVariantProp
-          )) as keyof typeof variants[typeof variant];
+          )) as keyof (typeof variants)[typeof variant];
 
         return variants[variant][variantKey];
       }
@@ -125,3 +130,5 @@ export const cva =
       props?.className
     );
   };
+
+export const cva = config({ cx });


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

As per discussion #100 this exports a `config` function from cva to allow replacing the default `cx` wrapper with a custom one. The `cva` function now extends/calls the `config` function with the default `clsx`

### Additional context

This is useful as it allow you to extend the default functionality with e.g. [Tailwind Merge](https://github.com/dcastil/tailwind-merge):

```ts
import { config, cx, type CxOptions } from "cva";
import { twMerge } from "tailwind-merge";

export const cva = config({
  cx: (...inputs: CxOptions) => twMerge(cx(inputs)),
});
```

---

### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [X] New Feature
- [X] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md).
- [X] Follow the [Style Guide](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md#style-guide).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
