### PR TITLE
IntelliSense - Support Enums in cva<E>()

### DIFF
--- a/docs/pages/docs/getting-started/installation.mdx
+++ b/docs/pages/docs/getting-started/installation.mdx
@@ -70,7 +70,8 @@ You can enable autocompletion inside `cva` using the steps below:
     ```json
     {
       "tailwindCSS.experimental.classRegex": [
-        ["cva\\(([^)]*)\\)", "[\"'`]([^\"'`]*).*?[\"'`]"]
+        ["cva\\(([^)]*)\\)", "[\"'`]([^\"'`]*).*?[\"'`]"],
+        ["cva<.*?>\\(([^)]*)\\)", "[\"'`]([^\"'`]*).*?[\"'`]"],
       ]
     }
     ```


### PR DESCRIPTION
### Description

Currently IntelliSense adds Tailwind Styles for this pattern:
```typescript
const styles = cva('here', {
   variants: {
      appearance: {
         raised: 'and-here'
      }
   }
});
```

But if we were to write it with enums. IntelliSense does not recognize it.

```typescript
const styles = cva<{ appearance: 'raised' }>('not-here', {
  variants: {
    appearance: {
      raised: 'neither-here'
    }
  }
});
```

This PR adds another rule to the documentation that one can copy. IntelliSense now works with Enums, too.

### Additional context

I would have preferred this as a rule:
```
    ["cva(<.*?>)?\\(([^)]*)\\)", "[\"'`]([^\"'`]*).*?[\"'`]"]
```
But I am not familiar enough with IntellSense and the `classRegex` to know why this does not work. I guess that groups will be used as capture groups.

Luckily it still works, if we just add another entry to the `classRegex` array.


---

### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] New Feature
- [X] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md).
- [X] Follow the [Style Guide](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md#style-guide).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).

### Caveats

This only adds the support for IntelliSense and VSCode since I am unfamiliar with the other editors and do not have access to them. If this gets approved, maybe @The73756  can add it to their config.