### PR TITLE
Roll-your-own `unset`

### DIFF
--- a/packages/cva/README.md
+++ b/packages/cva/README.md
@@ -36,11 +36,29 @@ For documentation, visit [cva.style](https://cva.style).
      const after = cva({ base: "your-base-class" });
      ```
 
-2. **Use `"unset"` to disable a variant completely**
+2. **Roll-your-own `"unset"` to disable a variant completely**
 
-   Previously, passing `null` to a variant would provide the same behaviour – to match Stitches.js – however this caused some [concern and confusion](https://github.com/joe-bell/cva/discussions/97).
+   Previously, passing `null` to a variant would disable a variant completely – to match Stitches.js – however this caused some [concern and confusion](https://github.com/joe-bell/cva/discussions/97).
 
-   Instead, a more explicit `"unset"` option ([similar to the CSS keyword](https://developer.mozilla.org/en-US/docs/Web/CSS/unset)) is now available for use.
+   Instead, we recommend setting an explicit `"unset"` option ([similar to the CSS keyword](https://developer.mozilla.org/en-US/docs/Web/CSS/unset)) within your variant:
+
+   ```ts
+   import { cva } from "cva";
+
+   const button = cva({
+     base: "button",
+     variants: {
+       intent: {
+         unset: null,
+         primary: "button--primary",
+         secondary: "button--secondary",
+       },
+     },
+   });
+
+   button({ intent: "unset" });
+   // => "button"
+   ```
 
 3. Utilize `swc` minification to improve bundlesize
 
@@ -61,6 +79,8 @@ For documentation, visit [cva.style](https://cva.style).
 Builds a `cva` component
 
 ```ts
+import { cva } from "cva";
+
 const component = cva(options);
 ```
 
@@ -80,6 +100,8 @@ Generate `cx` and `cva` functions based on your preferred configuration.
 Store in a `cva.config.ts` file, and import across your project.
 
 ```ts
+import { cva } from "cva";
+
 // cva.config.ts
 export const { cva, cx } = defineConfig(options);
 ```

--- a/packages/cva/src/index.test.ts
+++ b/packages/cva/src/index.test.ts
@@ -122,6 +122,7 @@ describe("cva", () => {
       const buttonWithoutBaseWithoutDefaultsString = cva({
         variants: {
           intent: {
+            unset: null,
             primary:
               "button--primary bg-blue-500 text-white border-transparent hover:bg-blue-600",
             secondary:
@@ -139,15 +140,18 @@ describe("cva", () => {
             ],
           },
           disabled: {
+            unset: null,
             true: "button--disabled opacity-050 cursor-not-allowed",
             false: "button--enabled cursor-pointer",
           },
           size: {
+            unset: null,
             small: "button--small text-sm py-1 px-2",
             medium: "button--medium text-base py-2 px-4",
             large: "button--large text-lg py-2.5 px-4",
           },
           m: {
+            unset: null,
             0: "m-0",
             1: "m-1",
           },
@@ -176,6 +180,7 @@ describe("cva", () => {
       const buttonWithoutBaseWithoutDefaultsWithClassNameString = cva({
         variants: {
           intent: {
+            unset: null,
             primary:
               "button--primary bg-blue-500 text-white border-transparent hover:bg-blue-600",
             secondary:
@@ -193,15 +198,18 @@ describe("cva", () => {
             ],
           },
           disabled: {
+            unset: null,
             true: "button--disabled opacity-050 cursor-not-allowed",
             false: "button--enabled cursor-pointer",
           },
           size: {
+            unset: null,
             small: "button--small text-sm py-1 px-2",
             medium: "button--medium text-base py-2 px-4",
             large: "button--large text-lg py-2.5 px-4",
           },
           m: {
+            unset: null,
             0: "m-0",
             1: "m-1",
           },
@@ -231,6 +239,7 @@ describe("cva", () => {
       const buttonWithoutBaseWithoutDefaultsArray = cva({
         variants: {
           intent: {
+            unset: null,
             primary: [
               "button--primary",
               "bg-blue-500",
@@ -262,15 +271,18 @@ describe("cva", () => {
             ],
           },
           disabled: {
+            unset: null,
             true: ["button--disabled", "opacity-050", "cursor-not-allowed"],
             false: ["button--enabled", "cursor-pointer"],
           },
           size: {
+            unset: null,
             small: ["button--small", "text-sm", "py-1", "px-2"],
             medium: ["button--medium", "text-base", "py-2", "px-4"],
             large: ["button--large", "text-lg", "py-2.5", "px-4"],
           },
           m: {
+            unset: null,
             0: "m-0",
             1: "m-1",
           },
@@ -299,6 +311,7 @@ describe("cva", () => {
       const buttonWithoutBaseWithoutDefaultsWithClassNameArray = cva({
         variants: {
           intent: {
+            unset: null,
             primary: [
               "button--primary",
               "bg-blue-500",
@@ -330,15 +343,18 @@ describe("cva", () => {
             ],
           },
           disabled: {
+            unset: null,
             true: ["button--disabled", "opacity-050", "cursor-not-allowed"],
             false: ["button--enabled", "cursor-pointer"],
           },
           size: {
+            unset: null,
             small: ["button--small", "text-sm", "py-1", "px-2"],
             medium: ["button--medium", "text-base", "py-2", "px-4"],
             large: ["button--large", "text-lg", "py-2.5", "px-4"],
           },
           m: {
+            unset: null,
             0: "m-0",
             1: "m-1",
           },
@@ -464,6 +480,7 @@ describe("cva", () => {
         base: "button font-semibold border rounded",
         variants: {
           intent: {
+            unset: null,
             primary:
               "button--primary bg-blue-500 text-white border-transparent hover:bg-blue-600",
             secondary:
@@ -481,15 +498,18 @@ describe("cva", () => {
             ],
           },
           disabled: {
+            unset: null,
             true: "button--disabled opacity-050 cursor-not-allowed",
             false: "button--enabled cursor-pointer",
           },
           size: {
+            unset: null,
             small: "button--small text-sm py-1 px-2",
             medium: "button--medium text-base py-2 px-4",
             large: "button--large text-lg py-2.5 px-4",
           },
           m: {
+            unset: null,
             0: "m-0",
             1: "m-1",
           },
@@ -534,6 +554,7 @@ describe("cva", () => {
         base: "button font-semibold border rounded",
         variants: {
           intent: {
+            unset: null,
             primary:
               "button--primary bg-blue-500 text-white border-transparent hover:bg-blue-600",
             secondary:
@@ -551,15 +572,18 @@ describe("cva", () => {
             ],
           },
           disabled: {
+            unset: null,
             true: "button--disabled opacity-050 cursor-not-allowed",
             false: "button--enabled cursor-pointer",
           },
           size: {
+            unset: null,
             small: "button--small text-sm py-1 px-2",
             medium: "button--medium text-base py-2 px-4",
             large: "button--large text-lg py-2.5 px-4",
           },
           m: {
+            unset: null,
             0: "m-0",
             1: "m-1",
           },
@@ -605,6 +629,7 @@ describe("cva", () => {
         base: ["button", "font-semibold", "border", "rounded"],
         variants: {
           intent: {
+            unset: null,
             primary: [
               "button--primary",
               "bg-blue-500",
@@ -636,15 +661,18 @@ describe("cva", () => {
             ],
           },
           disabled: {
+            unset: null,
             true: ["button--disabled", "opacity-050", "cursor-not-allowed"],
             false: ["button--enabled", "cursor-pointer"],
           },
           size: {
+            unset: null,
             small: ["button--small", "text-sm", "py-1", "px-2"],
             medium: ["button--medium", "text-base", "py-2", "px-4"],
             large: ["button--large", "text-lg", "py-2.5", "px-4"],
           },
           m: {
+            unset: null,
             0: "m-0",
             1: "m-1",
           },
@@ -689,6 +717,7 @@ describe("cva", () => {
         base: ["button", "font-semibold", "border", "rounded"],
         variants: {
           intent: {
+            unset: null,
             primary: [
               "button--primary",
               "bg-blue-500",
@@ -720,15 +749,18 @@ describe("cva", () => {
             ],
           },
           disabled: {
+            unset: null,
             true: ["button--disabled", "opacity-050", "cursor-not-allowed"],
             false: ["button--enabled", "cursor-pointer"],
           },
           size: {
+            unset: null,
             small: ["button--small", "text-sm", "py-1", "px-2"],
             medium: ["button--medium", "text-base", "py-2", "px-4"],
             large: ["button--large", "text-lg", "py-2.5", "px-4"],
           },
           m: {
+            unset: null,
             0: "m-0",
             1: "m-1",
           },
@@ -878,6 +910,7 @@ describe("cva", () => {
         base: "button font-semibold border rounded",
         variants: {
           intent: {
+            unset: null,
             primary:
               "button--primary bg-blue-500 text-white border-transparent hover:bg-blue-600",
             secondary:
@@ -895,10 +928,12 @@ describe("cva", () => {
             ],
           },
           disabled: {
+            unset: null,
             true: "button--disabled opacity-050 cursor-not-allowed",
             false: "button--enabled cursor-pointer",
           },
           size: {
+            unset: null,
             small: "button--small text-sm py-1 px-2",
             medium: "button--medium text-base py-2 px-4",
             large: "button--large text-lg py-2.5 px-4",
@@ -938,6 +973,7 @@ describe("cva", () => {
         base: "button font-semibold border rounded",
         variants: {
           intent: {
+            unset: null,
             primary:
               "button--primary bg-blue-500 text-white border-transparent hover:bg-blue-600",
             secondary:
@@ -955,10 +991,12 @@ describe("cva", () => {
             ],
           },
           disabled: {
+            unset: null,
             true: "button--disabled opacity-050 cursor-not-allowed",
             false: "button--enabled cursor-pointer",
           },
           size: {
+            unset: null,
             small: "button--small text-sm py-1 px-2",
             medium: "button--medium text-base py-2 px-4",
             large: "button--large text-lg py-2.5 px-4",
@@ -999,6 +1037,7 @@ describe("cva", () => {
         base: ["button", "font-semibold", "border", "rounded"],
         variants: {
           intent: {
+            unset: null,
             primary: [
               "button--primary",
               "bg-blue-500",
@@ -1030,10 +1069,12 @@ describe("cva", () => {
             ],
           },
           disabled: {
+            unset: null,
             true: ["button--disabled", "opacity-050", "cursor-not-allowed"],
             false: ["button--enabled", "cursor-pointer"],
           },
           size: {
+            unset: null,
             small: ["button--small", "text-sm", "py-1", "px-2"],
             medium: ["button--medium", "text-base", "py-2", "px-4"],
             large: ["button--large", "text-lg", "py-2.5", "px-4"],
@@ -1073,6 +1114,7 @@ describe("cva", () => {
         base: ["button", "font-semibold", "border", "rounded"],
         variants: {
           intent: {
+            unset: null,
             primary: [
               "button--primary",
               "bg-blue-500",
@@ -1104,10 +1146,12 @@ describe("cva", () => {
             ],
           },
           disabled: {
+            unset: null,
             true: ["button--disabled", "opacity-050", "cursor-not-allowed"],
             false: ["button--enabled", "cursor-pointer"],
           },
           size: {
+            unset: null,
             small: ["button--small", "text-sm", "py-1", "px-2"],
             medium: ["button--medium", "text-base", "py-2", "px-4"],
             large: ["button--large", "text-lg", "py-2.5", "px-4"],
@@ -1246,6 +1290,7 @@ describe("cva", () => {
         base: "button font-semibold border rounded",
         variants: {
           intent: {
+            unset: null,
             primary:
               "button--primary bg-blue-500 text-white border-transparent hover:bg-blue-600",
             secondary:
@@ -1263,10 +1308,12 @@ describe("cva", () => {
             ],
           },
           disabled: {
+            unset: null,
             true: "button--disabled opacity-050 cursor-not-allowed",
             false: "button--enabled cursor-pointer",
           },
           size: {
+            unset: null,
             small: "button--small text-sm py-1 px-2",
             medium: "button--medium text-base py-2 px-4",
             large: "button--large text-lg py-2.5 px-4",
@@ -1311,6 +1358,7 @@ describe("cva", () => {
         base: "button font-semibold border rounded",
         variants: {
           intent: {
+            unset: null,
             primary:
               "button--primary bg-blue-500 text-white border-transparent hover:bg-blue-600",
             secondary:
@@ -1328,10 +1376,12 @@ describe("cva", () => {
             ],
           },
           disabled: {
+            unset: null,
             true: "button--disabled opacity-050 cursor-not-allowed",
             false: "button--enabled cursor-pointer",
           },
           size: {
+            unset: null,
             small: "button--small text-sm py-1 px-2",
             medium: "button--medium text-base py-2 px-4",
             large: "button--large text-lg py-2.5 px-4",
@@ -1377,6 +1427,7 @@ describe("cva", () => {
         base: ["button", "font-semibold", "border", "rounded"],
         variants: {
           intent: {
+            unset: null,
             primary: [
               "button--primary",
               "bg-blue-500",
@@ -1408,10 +1459,12 @@ describe("cva", () => {
             ],
           },
           disabled: {
+            unset: null,
             true: ["button--disabled", "opacity-050", "cursor-not-allowed"],
             false: ["button--enabled", "cursor-pointer"],
           },
           size: {
+            unset: null,
             small: ["button--small", "text-sm", "py-1", "px-2"],
             medium: ["button--medium", "text-base", "py-2", "px-4"],
             large: ["button--large", "text-lg", "py-2.5", "px-4"],
@@ -1456,6 +1509,7 @@ describe("cva", () => {
         base: ["button", "font-semibold", "border", "rounded"],
         variants: {
           intent: {
+            unset: null,
             primary: [
               "button--primary",
               "bg-blue-500",
@@ -1487,10 +1541,12 @@ describe("cva", () => {
             ],
           },
           disabled: {
+            unset: null,
             true: ["button--disabled", "opacity-050", "cursor-not-allowed"],
             false: ["button--enabled", "cursor-pointer"],
           },
           size: {
+            unset: null,
             small: ["button--small", "text-sm", "py-1", "px-2"],
             medium: ["button--medium", "text-base", "py-2", "px-4"],
             large: ["button--large", "text-lg", "py-2.5", "px-4"],

--- a/packages/cva/src/index.ts
+++ b/packages/cva/src/index.ts
@@ -48,10 +48,7 @@ export type CXReturn = ReturnType<CX>;
 type CVAConfigBase = { base?: ClassValue };
 type CVAVariantShape = Record<string, Record<string, ClassValue>>;
 type CVAVariantSchema<V extends CVAVariantShape> = {
-  [Variant in keyof V]?:
-    | StringToBoolean<keyof V[Variant]>
-    | "unset"
-    | undefined;
+  [Variant in keyof V]?: StringToBoolean<keyof V[Variant]> | undefined;
 };
 type CVAClassProp =
   | {
@@ -133,8 +130,6 @@ export const defineConfig: DefineConfig = (options) => {
       (variant: keyof typeof variants) => {
         const variantProp = props?.[variant as keyof typeof props];
         const defaultVariantProp = defaultVariants?.[variant];
-
-        if (variantProp === "unset") return undefined;
 
         const variantKey = (falsyToString(variantProp) ||
           falsyToString(


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Removes the `"unset"` value from `cva@1.0` in favour of a more explicit manual setup

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md).
- [ ] Follow the [Style Guide](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md#style-guide).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
