### PR TITLE
Remove extra brackets from installation.mdx

### DIFF
--- a/docs/pages/docs/getting-started/installation.mdx
+++ b/docs/pages/docs/getting-started/installation.mdx
@@ -70,7 +70,7 @@ You can enable autocompletion inside `cva` using the steps below:
     ```json
     {
       "tailwindCSS.experimental.classRegex": [
-        ["cva\\(([^)]*)\\)", "[\"'`]([^\"'`]*).*?[\"'`]"]
+        "cva\\(([^)]*)\\)", "[\"'`]([^\"'`]*).*?[\"'`]"
       ]
     }
     ```


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Removed extra array brackets from the settings.json snippet regarding Tailwind IntelliSense setup.

### Additional context

After updating my settings.json (VS Code) according to the docs, I found that intellisense was not working with tailwind. Once I removed the extra array brackets in the snippet, intellisense is working like a charm.

---

### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md).
- [x] Follow the [Style Guide](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md#style-guide).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
