### PR TITLE
fix: allow `readonly` arrays in `compoundVariants`

### DIFF
--- a/packages/class-variance-authority/src/index.ts
+++ b/packages/class-variance-authority/src/index.ts
@@ -35,6 +35,7 @@ type ConfigVariantsMulti<T extends ConfigSchema> = {
   [Variant in keyof T]?:
     | StringToBoolean<keyof T[Variant]>
     | StringToBoolean<keyof T[Variant]>[]
+    | ReadonlyArray<StringToBoolean<keyof T[Variant]>>
     | undefined;
 };
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR allows developers to use `as const` inside `compoundVariants` for arrays of variants, not just single variants.

```ts
import { cva } from 'class-variance-authority';

export const demoVariants = cva('bg-red-500', {
  variants: {
    foo: {
      a: 'p-1',
      b: 'p-2',
      c: 'p-3',
    },
    bar: {
      x: 'm-1',
      y: 'm-2',
      z: 'm-3',
    },
  },
  compoundVariants: [
    {
      foo: 'a' as const,          // ⬅️ previously possible
      bar: ['x', 'y'] as const,   // ⬅️ previously not allowed by typings: Type 'readonly ["x", "y"]' is not assignable to type '"x" | "y" | "z" | ("x" | "y" | "z")[] | null | undefined' ts(2322)
      class: 'm-0 p-0',
    },
  ],
  defaultVariants: {
    foo: 'a',
    bar: 'x',
  },
});
```

Adding support for `as const` after arrays is helpful for users of [`eslint-plugin-tailwindcss`](https://www.npmjs.com/package/eslint-plugin-tailwindcss) with [`tailwindcss/no-custom-classname`](https://github.com/francoismassart/eslint-plugin-tailwindcss/blob/HEAD/docs/rules/no-custom-classname.md) enabled. Here is why: https://github.com/francoismassart/eslint-plugin-tailwindcss/issues/193#issuecomment-1429895036.

### Additional context

See https://github.com/joe-bell/cva/discussions/195

I don’t know a full range of versions where `ReadonlyArray` is supported, but it’s mentioned [in TS 3.4 release](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-4.html#improvements-for-readonlyarray-and-readonly-tuples) (3 years ago). Guess it’s safe to use this utility type.


---

### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [x] Bug fix (for TS users)
- ~~New Feature~~
- ~~Documentation update~~
- ~~Other~~

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md).
- [x] Follow the [Style Guide](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md#style-guide).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
