### PR TITLE
chore: optimize compoundVariants calc

### DIFF
--- a/packages/class-variance-authority/src/index.ts
+++ b/packages/class-variance-authority/src/index.ts
@@ -76,39 +76,44 @@ export const cva =
       }
     );
 
-    const propsWithoutUndefined =
-      props &&
-      Object.entries(props).reduce((acc, [key, value]) => {
-        if (value === undefined) {
-          return acc;
-        }
+    let getCompoundVariantClassNames;
+    if (config?.compoundVariants) {
+      const combinedProps = props
+        ? Object.entries(props).reduce(
+            (acc, [key, value]) => {
+              if (value === undefined) {
+                return acc;
+              }
 
-        acc[key] = value;
-        return acc;
-      }, {} as Record<string, unknown>);
+              acc[key] = value;
+              return acc;
+            },
+            { ...defaultVariants } as Record<string, unknown>
+          )
+        : defaultVariants;
 
-    const getCompoundVariantClassNames = config?.compoundVariants?.reduce(
-      (
-        acc,
-        { class: cvClass, className: cvClassName, ...compoundVariantOptions }
-      ) =>
-        Object.entries(compoundVariantOptions).every(([key, value]) =>
-          Array.isArray(value)
-            ? value.includes(
-                {
-                  ...defaultVariants,
-                  ...propsWithoutUndefined,
-                }[key]
-              )
-            : {
-                ...defaultVariants,
-                ...propsWithoutUndefined,
-              }[key] === value
-        )
-          ? [...acc, cvClass, cvClassName]
-          : acc,
-      [] as ClassValue[]
-    );
+      getCompoundVariantClassNames =
+        combinedProps &&
+        config.compoundVariants.reduce(
+          (
+            acc,
+            {
+              class: cvClass,
+              className: cvClassName,
+              ...compoundVariantOptions
+            }
+          ) =>
+            Object.entries(compoundVariantOptions).every(([key, value]) => {
+              const propVal = combinedProps[key];
+              return Array.isArray(value)
+                ? value.includes(propVal)
+                : propVal === value;
+            })
+              ? [...acc, cvClass, cvClassName]
+              : acc,
+          [] as ClassValue[]
+        );
+    }
 
     return cx(
       base,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This merges the props and default variants only once instead of for every compound variant set.

---

### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md).
- [x] Follow the [Style Guide](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md#style-guide).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
