### PR TITLE
docs: fix license url

### DIFF
--- a/docs/beta/src/content/docs/index.mdx
+++ b/docs/beta/src/content/docs/index.mdx
@@ -39,4 +39,4 @@ Creating variants with the "traditional" CSS approach can become an arduous task
 
 ## License
 
-[Apache-2.0 License](/LICENSE) © [Joe Bell](https://twitter.com/joebell_)
+[Apache-2.0 License](https://github.com/joe-bell/cva/blob/main/LICENSE) © [Joe Bell](https://twitter.com/joebell_)

--- a/docs/latest/pages/docs/index.mdx
+++ b/docs/latest/pages/docs/index.mdx
@@ -32,4 +32,4 @@ Creating variants with the "traditional" CSS approach can become an arduous task
 
 ## License
 
-[Apache-2.0 License](/LICENSE) © [Joe Bell](https://twitter.com/joebell_)
+[Apache-2.0 License](https://github.com/joe-bell/cva/blob/main/LICENSE) © [Joe Bell](https://twitter.com/joebell_)


### PR DESCRIPTION
### Description

Currently [LICENSE](https://cva.style/docs#license) section in documentation site seems to be broken.
This PR fixes LICENSE broken link in documentation site.

---

### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] New Feature
- [X] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md).
- [X] Follow the [Style Guide](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md#style-guide).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
