### PR TITLE
fix: cva x tailwind config for neovim

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
   examples:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
     if: github.event_name == 'pull_request'
     steps:
@@ -63,6 +64,7 @@ jobs:
           header: "Examples"
           recreate: true
           path: TMP_EXAMPLES.md
+          GITHUB_TOKEN: ${{ secrets.STICKY_PR_COMMENT_PAT }}
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/docs/latest/pages/docs/getting-started/installation.mdx
+++ b/docs/latest/pages/docs/getting-started/installation.mdx
@@ -84,13 +84,13 @@ You can enable autocompletion inside `cva` using the steps below:
     2. Add the following configuration:
 
     ```lua
-    lspconfig.tailwindcss.setup({
+    require 'lspconfig'.tailwindcss.setup({
       settings = {
         tailwindCSS = {
           experimental = {
             classRegex = {
-              ["cva\\(([^)]*)\\)", "[\"'`]([^\"'`]*).*?[\"'`]"],
-              ["cx\\(([^)]*)\\)", "(?:'|\"|`)([^']*)(?:'|\"|`)"]
+              { "cva\\(([^)]*)\\)", "[\"'`]([^\"'`]*).*?[\"'`]" },
+              { "cx\\(([^)]*)\\)", "(?:'|\"|`)([^']*)(?:'|\"|`)" }
             },
           },
         },


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Fixes incorrect lua table syntax when adding intellisense for neovim editors

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context
lua tables are enclosed in curly brackets rather than square brackets

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request?
Fix docs
<!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md).
- [x] Follow the [Style Guide](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md#style-guide).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
