### PR TITLE
docs: Fix typo in `twMerge` example of beta installation docs

### DIFF
--- a/docs/beta/src/content/docs/getting-started/installation.mdx
+++ b/docs/beta/src/content/docs/getting-started/installation.mdx
@@ -5,7 +5,7 @@ title: Installation
 import { Tabs, TabItem } from "@astrojs/starlight/components";
 
 :::caution
-**You are currently viewing the docs for `cva@beta`**  
+**You are currently viewing the docs for `cva@beta`**
 For stable documentation, please visit [cva.style](https://cva.style).
 :::
 
@@ -25,11 +25,11 @@ For stable documentation, please visit [cva.style](https://cva.style).
 
   </TabItem>
   <TabItem label="yarn">
-  
+
     ```sh
     yarn add cva@beta
     ```
-  
+
   </TabItem>
 </Tabs>
 
@@ -129,10 +129,12 @@ export const button = cva({
   // 1. `twMerge` strips out `bg-gray-200`…
   base: "font-semibold bg-gray-200 border rounded",
   variants: {
-    // 2. …as variant `bg-*` values take precedence
-    primary: "bg-blue-500 text-white border-transparent hover:bg-blue-600",
-    secondary: "bg-white text-gray-800 border-gray-400 hover:bg-gray-100",
-  },
+    intent: {
+      // 2. …as variant `bg-*` values take precedence
+      primary: "bg-blue-500 text-white border-transparent hover:bg-blue-600",
+      secondary: "bg-white text-gray-800 border-gray-400 hover:bg-gray-100",
+    },
+  }
   defaultVariants: {
     intent: "primary",
   },


### PR DESCRIPTION
### Description

Fixes a very small, but potentially misleading typo in the `twMerge` [example of the beta docs](https://beta.cva.style/getting-started/installation/).

`intent` could seem like a special property, whereas in fact it's just an arbitrary name of a variant. 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md).
- [x] Follow the [Style Guide](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md#style-guide).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
