### PR TITLE
RFC: Support for boolean variant aliases

### DIFF
--- a/packages/cva/src/index.test.ts
+++ b/packages/cva/src/index.test.ts
@@ -1336,6 +1336,44 @@ describe("cva", () => {
           );
         });
       });
+      test("boolean variant alias", () => {
+        const example = cva({
+          variants: {
+            _color: { primary: "class-a", secondary: "class-b" },
+            size: { sm: "class-s", md: "class-m", lg: "class-l" },
+          },
+        });
+        expect(example({ primary: true, size: "md" })).toBe("class-a class-m");
+      });
+      test("boolean variant alias - error: not aliased", () => {
+        const example = cva({
+          variants: {
+            _color: { primary: "class-a", secondary: "class-b" },
+            size: { sm: "class-s", md: "class-m", lg: "class-l" },
+          },
+        });
+        // @ts-expect-error
+        expect(example({ primary: true, md: true })).toBe("class-a");
+      });
+      test("boolean variant alias - error: override", () => {
+        const example = cva({
+          variants: {
+            _color: { primary: "class-a", secondary: "class-b" },
+            size: { sm: "class-s", md: "class-m", lg: "class-l" },
+          },
+        });
+        // @ts-expect-error
+        expect(example({ primary: true, secondary: true })).toBe("class-a");
+      });
+      test("boolean variant alias without alias", () => {
+        const example = cva({
+          variants: {
+            _color: { primary: "class-a", secondary: "class-b" },
+            size: { sm: "class-s", md: "class-m", lg: "class-l" },
+          },
+        });
+        expect(example({ _color: "primary" })).toBe("class-a");
+      });
     });
 
     describe("with defaults", () => {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
This PR is a proof of concept for a feature: I often find myself creating variants using a series of mutually exclusive boolean aliases for brevity and readability.

For example, in the case of a React component I'd much rather have: `<Component primary />` than `<Component intent="primary" />`.

This feature would allow variants to function as such when prefixed with an underscore:

```ts
const example = cva({
  variants: {
    _intent: { primary: "class-a", secondary: "class-b" },
    size: { sm: "class-s", md: "class-m", lg: "class-l" },
  },
});

example({ _intent: "primary",  size: "md" });  // Outputs "class-a class-m"
example({ primary: true,  size: "md" });  // Also outputs "class-a class-m"
```
The mutually exclusive nature of the variants is enforced with typing:
```ts
example({ primary: true,  secondary: true});  // Causes a typescript error

example({ _intent: "primary",  secondary: true});  
// Valid but the alias will override the variant resulting in "class-b"
```
### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
My naming for this pattern is all over the place, I wasn't sure what to call it. (Exclusive variant aliases?) I've added a basic rough implementation with typescript enforcement and some tests. I'm  of course open to any feedback or suggestions.

---

### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [X] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md).
- [X] Follow the [Style Guide](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md#style-guide).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
