### PR TITLE
fix(docs): update broken links to getting-started pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.repository_owner_id == '7349341'
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
           header: "Examples"
           recreate: true
           path: TMP_EXAMPLES.md
+          GITHUB_TOKEN: ${{ secrets.STICKY_COMMENT_TOKEN }}
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
   examples:
     runs-on: ubuntu-latest
     env:
-      GITHUB_TOKEN: ${{ github.token }}
+      GITHUB_TOKEN: ${{ secrets.STICKY_COMMENT_TOKEN }}
     permissions:
       pull-requests: write
     if: github.event_name == 'pull_request' && github.repository_owner_id == '7349341'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,6 @@ jobs:
       - run: pnpm check
   examples:
     runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{ secrets.STICKY_COMMENT_TOKEN }}
     permissions:
       pull-requests: write
     if: github.event_name == 'pull_request' && github.repository_owner_id == '7349341'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,8 @@ jobs:
       - run: pnpm check
   examples:
     runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ github.token }}
     permissions:
       pull-requests: write
     if: github.event_name == 'pull_request' && github.repository_owner_id == '7349341'
@@ -63,7 +65,6 @@ jobs:
           header: "Examples"
           recreate: true
           path: TMP_EXAMPLES.md
-          GITHUB_TOKEN: ${{ secrets.STICKY_COMMENT_TOKEN }}
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/docs/beta/src/content/docs/getting-started/whats-new.mdx
+++ b/docs/beta/src/content/docs/getting-started/whats-new.mdx
@@ -13,13 +13,13 @@ What's changed since `class-variance-authority@0.*`?
 
 ### 1. `compose`
 
-Shallow merge any number of cva components into a single component via the new [`compose` method](/docs/getting-started/composing-components).
+Shallow merge any number of cva components into a single component via the new [`compose` method](/getting-started/composing-components).
 
 ### 2. `defineConfig`
 
-Extend `cva` via the new [`defineConfig` API](/docs/api-reference#defineconfig).
+Extend `cva` via the new [`defineConfig` API](/api-reference#defineconfig).
 
-Want to use `cva`/`cx` with `tailwind-merge`? [No problem](/docs/getting-started/installation#handling-style-conflicts)!
+Want to use `cva`/`cx` with `tailwind-merge`? [No problem](/getting-started/installation#handling-style-conflicts)!
 
 ## Enhancements
 
@@ -53,7 +53,7 @@ Base styles are now applied via the named `base` property.
 
 Previously, passing `null` to a variant would disable a variant completely – to match the behaviour of Stitches.js – however this [caused a great deal of confusion](https://github.com/joe-bell/cva/discussions/97).
 
-Instead, we now recommend explicitly [rolling your own `unset` variant](/docs/getting-started/variants#disabling-variants).
+Instead, we now recommend explicitly [rolling your own `unset` variant](/getting-started/variants#disabling-variants).
 
 ### 4. Clearer Type Guards
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The links in the [getting-started/whats-new](https://beta.cva.style/getting-started/whats-new/) section of the beta docs are all prefixed with `/docs` causing them to `404`.

I removed the `/docs` prefix as it is not configured that way in the starlight config.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md).
- [x] Follow the [Style Guide](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md#style-guide).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
