### PR TITLE
fix: improve type constraints in cva function

### DIFF
--- a/packages/class-variance-authority/src/index.ts
+++ b/packages/class-variance-authority/src/index.ts
@@ -12,7 +12,7 @@ export type VariantProps<Component extends (...args: any) => any> = Omit<
   "class" | "className"
 >;
 
-const falsyToString = <T extends unknown>(value: T) =>
+const falsyToString = <T>(value: T) =>
   typeof value === "boolean" ? `${value}` : value === 0 ? "0" : value;
 
 /* cx
@@ -38,25 +38,23 @@ type ConfigVariantsMulti<T extends ConfigSchema> = {
     | undefined;
 };
 
-type Config<T> = T extends ConfigSchema
-  ? {
-      variants?: T;
-      defaultVariants?: ConfigVariants<T>;
-      compoundVariants?: (T extends ConfigSchema
-        ? (ConfigVariants<T> | ConfigVariantsMulti<T>) & ClassProp
-        : ClassProp)[];
-    }
-  : never;
+type Config<T extends ConfigSchema> = {
+  variants?: T;
+  defaultVariants?: ConfigVariants<T>;
+  compoundVariants?:
+    (T extends ConfigSchema
+      ? (ConfigVariants<T> | ConfigVariantsMulti<T>) & ClassProp
+      : ClassProp)[];
+};
 
-type Props<T> = T extends ConfigSchema
-  ? ConfigVariants<T> & ClassProp
+type Props<T> = T extends ConfigSchema ? ConfigVariants<T> & ClassProp
   : ClassProp;
 
 export const cva =
-  <T>(base?: ClassValue, config?: Config<T>) =>
-  (props?: Props<T>) => {
-    if (config?.variants == null)
+  <T extends ConfigSchema>(base?: ClassValue, config?: Config<T>) => (props?: Props<T>) => {
+    if (config?.variants == null) {
       return cx(base, props?.class, props?.className);
+    }
 
     const { variants, defaultVariants } = config;
 
@@ -76,8 +74,7 @@ export const cva =
       },
     );
 
-    const propsWithoutUndefined =
-      props &&
+    const propsWithoutUndefined = props &&
       Object.entries(props).reduce(
         (acc, [key, value]) => {
           if (value === undefined) {
@@ -96,18 +93,18 @@ export const cva =
         { class: cvClass, className: cvClassName, ...compoundVariantOptions },
       ) =>
         Object.entries(compoundVariantOptions).every(([key, value]) =>
-          Array.isArray(value)
-            ? value.includes(
+            Array.isArray(value)
+              ? value.includes(
                 {
                   ...defaultVariants,
                   ...propsWithoutUndefined,
                 }[key],
               )
-            : {
+              : {
                 ...defaultVariants,
                 ...propsWithoutUndefined,
-              }[key] === value,
-        )
+              }[key] === value
+          )
           ? [...acc, cvClass, cvClassName]
           : acc,
       [] as ClassValue[],

--- a/packages/class-variance-authority/src/index.ts
+++ b/packages/class-variance-authority/src/index.ts
@@ -42,16 +42,14 @@ type Config<T extends ConfigSchema> = {
   variants?: T;
   defaultVariants?: ConfigVariants<T>;
   compoundVariants?:
-    (T extends ConfigSchema
-      ? (ConfigVariants<T> | ConfigVariantsMulti<T>) & ClassProp
-      : ClassProp)[];
+    ((ConfigVariants<T> | ConfigVariantsMulti<T>) & ClassProp)[];
 };
 
-type Props<T> = T extends ConfigSchema ? ConfigVariants<T> & ClassProp
-  : ClassProp;
+type Props<T extends ConfigSchema> = ConfigVariants<T> & ClassProp;
 
 export const cva =
-  <T extends ConfigSchema>(base?: ClassValue, config?: Config<T>) => (props?: Props<T>) => {
+  <T extends ConfigSchema>(base?: ClassValue, config?: Config<T>) =>
+  (props?: Props<T>) => {
     if (config?.variants == null) {
       return cx(base, props?.class, props?.className);
     }

--- a/packages/class-variance-authority/src/index.ts
+++ b/packages/class-variance-authority/src/index.ts
@@ -73,7 +73,7 @@ export const cva =
     );
 
     const propsWithoutUndefined = props &&
-      Object.entries(props).reduce(
+      Object.entries(props).reduce<Record<string, unknown>>(
         (acc, [key, value]) => {
           if (value === undefined) {
             return acc;
@@ -82,10 +82,10 @@ export const cva =
           acc[key] = value;
           return acc;
         },
-        {} as Record<string, unknown>,
+        {},
       );
 
-    const getCompoundVariantClassNames = config?.compoundVariants?.reduce(
+    const getCompoundVariantClassNames = config?.compoundVariants?.reduce<ClassValue[]>(
       (
         acc,
         { class: cvClass, className: cvClassName, ...compoundVariantOptions },
@@ -105,7 +105,7 @@ export const cva =
           )
           ? [...acc, cvClass, cvClassName]
           : acc,
-      [] as ClassValue[],
+      [],
     );
 
     return cx(


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR intends to fine-tune the types surrounding the main `cva` function following a small problem I encountered when using cva in a different project.

### Additional context

My contribution is entirely within `packages/class-variance-authority/src/index.ts`. The `Config<T>` type didn't properly constrain the type parameter, instead using a type ternary to evaluate to `never` when `T` didn't extend `ConfigSchema`:

```ts
type Config<T> = T extends ConfigSchema ? {
  variants?: T;
  defaultVariants?: ConfigVariants<T>;
  compoundVariants?:
    (T extends ConfigSchema
      ? (ConfigVariants<T> | ConfigVariantsMulti<T>) & ClassProp
      : ClassProp)[];
} : never;
```

In doing so, the second parameter in `cva` would often complain that the type of its argument is not assignable to `undefined`, essentially `undefined | never`. I didn't know how to fix that because I had to follow a type I couldn't introspect very well in order to introspect/know the type (ie have autocomplete, etc). I simply moved the extension constraint to the type parameter instead of in a type ternary:

```ts
type Config<T extends ConfigSchema> = {
  variants?: T;
  defaultVariants?: ConfigVariants<T>;
  compoundVariants?:
    (T extends ConfigSchema
      ? (ConfigVariants<T> | ConfigVariantsMulti<T>) & ClassProp
      : ClassProp)[];
} ;
```

---

### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md).
- [x] Follow the [Style Guide](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md#style-guide).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
