### PR TITLE
Export config type, for use when extending CVA

### DIFF
--- a/packages/class-variance-authority/src/index.ts
+++ b/packages/class-variance-authority/src/index.ts
@@ -38,7 +38,7 @@ type ConfigVariantsMulti<T extends ConfigSchema> = {
     | undefined;
 };
 
-type Config<T> = T extends ConfigSchema
+export type Config<T> = T extends ConfigSchema
   ? {
       variants?: T;
       defaultVariants?: ConfigVariants<T>;


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Export Config type, so that if someone is extending CVA they can use the return type of the function without trying to derive it from the function itself

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md).
- [ ] Follow the [Style Guide](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md#style-guide).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
