### PR TITLE
Include `bigint` within `ClassValue`, export `Class*` types

### DIFF
--- a/packages/cva/src/index.ts
+++ b/packages/cva/src/index.ts
@@ -25,16 +25,17 @@ import { clsx } from "clsx";
 // TS2742 error. To combat this, we copy clsx's types manually.
 // Should this project move to JSDoc, this workaround would no longer be needed.
 
-type ClassValue =
+export type ClassValue =
   | ClassArray
   | ClassDictionary
   | string
   | number
+  | bigint
   | null
   | boolean
   | undefined;
-type ClassDictionary = Record<string, any>;
-type ClassArray = ClassValue[];
+export type ClassDictionary = Record<string, any>;
+export type ClassArray = ClassValue[];
 
 /* Utils
   ---------------------------------- */


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fixes #254 (hopefully)

* Updates the `ClassValue` type to match `clsx` (includes `bigint`)
* Exports all `Class*` types
  
    This has been a particularly popular request that I've been pretty stubborn about not including; now realising that there's probably no harm in providing this

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md).
- [x] Follow the [Style Guide](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md#style-guide).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
