### PR TITLE
docs: migrate from classregex to classfunctions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,12 +1,6 @@
 {
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "prettier.requireConfig": true,
-  "tailwindCSS.experimental.classRegex": [
-    [
-      ["classNames\\(([^)]*)\\)", "[\"'`]([^\"'`]*).*?[\"'`]"],
-      ["cva\\(([^)]*)\\)", "[\"'`]([^\"'`]*).*?[\"'`]"],
-      ["cx\\(([^)]*)\\)", "[\"'`]([^\"'`]*).*?[\"'`]"]
-    ]
-  ],
+  "tailwindCSS.classFunctions": ["classNames", "cva", "cx"],
   "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/docs/beta/src/content/docs/getting-started/installation.mdx
+++ b/docs/beta/src/content/docs/getting-started/installation.mdx
@@ -62,10 +62,7 @@ You can enable autocompletion inside `cva` using the steps below:
         ```json
         // .vscode/settings.json
         {
-          "tailwindCSS.experimental.classRegex": [
-            ["cva\\(((?:[^()]|\\([^()]*\\))*)\\)", "[\"'`]?([^\"'`]+)[\"'`]?"],
-            ["cx\\(((?:[^()]|\\([^()]*\\))*)\\)", "(?:'|\"|`)([^']*)(?:'|\"|`)"]
-          ]
+          "tailwindCSS.classFunctions": ["cva", "cx"],
         }
         ```
 
@@ -82,12 +79,7 @@ You can enable autocompletion inside `cva` using the steps below:
       "lsp": {
         "tailwindcss-language-server": {
           "settings": {
-            "experimental": {
-              "classRegex": [
-                ["cva\\(((?:[^()]|\\([^()]*\\))*)\\)", "[\"'`]?([^\"'`]+)[\"'`]?"],
-                ["cx\\(((?:[^()]|\\([^()]*\\))*)\\)", "(?:'|\"|`)([^']*)(?:'|\"|`)"]
-              ]
-            }
+            "classFunctions": ["cva", "cx"],
           }
         }
       }
@@ -105,12 +97,7 @@ You can enable autocompletion inside `cva` using the steps below:
         require 'lspconfig'.tailwindcss.setup({
           settings = {
             tailwindCSS = {
-              experimental = {
-                classRegex = {
-                  { "cva\\(((?:[^()]|\\([^()]*\\))*)\\)", "[\"'`]([^\"'`]*).*?[\"'`]" },
-                  { "cx\\(((?:[^()]|\\([^()]*\\))*)\\)", "(?:'|\"|`)([^']*)(?:'|\"|`)" }
-                },
-              },
+              classFunctions = { "cva", "cx" },
             },
           },
         })
@@ -128,12 +115,7 @@ You can enable autocompletion inside `cva` using the steps below:
 
         ```json
         {
-          "experimental": {
-            "classRegex": [
-              ["cva\\(((?:[^()]|\\([^()]*\\))*)\\)", "[\"'`]?([^\"'`]+)[\"'`]?"],
-              ["cx\\(((?:[^()]|\\([^()]*\\))*)\\)", "(?:'|\"|`)([^']*)(?:'|\"|`)"]
-            ]
-          }
+          "classFunctions": ["cva", "cx"]
         }
         ```
     </Steps>

--- a/docs/latest/pages/docs/getting-started/installation.mdx
+++ b/docs/latest/pages/docs/getting-started/installation.mdx
@@ -77,10 +77,7 @@ You can enable autocompletion inside `cva` using the steps below:
 
     ```json
     {
-      "tailwindCSS.experimental.classRegex": [
-        ["cva\\(((?:[^()]|\\([^()]*\\))*)\\)", "[\"'`]([^\"'`]*).*?[\"'`]"],
-        ["cx\\(((?:[^()]|\\([^()]*\\))*)\\)", "(?:'|\"|`)([^']*)(?:'|\"|`)"]
-      ]
+      "tailwindCSS.classFunctions": ["cva", "cx"]
     }
     ```
 
@@ -94,12 +91,7 @@ You can enable autocompletion inside `cva` using the steps below:
       "lsp": {
         "tailwindcss-language-server": {
           "settings": {
-            "experimental": {
-              "classRegex": [
-                ["cva\\(((?:[^()]|\\([^()]*\\))*)\\)", "[\"'`]([^\"'`]*).*?[\"'`]"],
-                ["cx\\(((?:[^()]|\\([^()]*\\))*)\\)", "(?:'|\"|`)([^']*)(?:'|\"|`)"]
-              ]
-            }
+            "classFunctions": ["cva", "cx"],
           }
         }
       }
@@ -117,12 +109,7 @@ You can enable autocompletion inside `cva` using the steps below:
     require 'lspconfig'.tailwindcss.setup({
       settings = {
         tailwindCSS = {
-          experimental = {
-            classRegex = {
-              { "cva\\(((?:[^()]|\\([^()]*\\))*)\\)", "[\"'`]([^\"'`]*).*?[\"'`]" },
-              { "cx\\(((?:[^()]|\\([^()]*\\))*)\\)", "(?:'|\"|`)([^']*)(?:'|\"|`)" }
-            },
-          },
+          classFunctions = { "cva", "cx" },
         },
       },
     })
@@ -139,12 +126,7 @@ You can enable autocompletion inside `cva` using the steps below:
 
     ```json
     {
-      "experimental": {
-        "classRegex": [
-          ["cva\\(((?:[^()]|\\([^()]*\\))*)\\)", "[\"'`]([^\"'`]*).*?[\"'`]"],
-          ["cx\\(((?:[^()]|\\([^()]*\\))*)\\)", "(?:'|\"|`)([^']*)(?:'|\"|`)"]
-        ]
-      }
+      "classFunctions": ["cva", "cx"]
     }
     ```
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

To use Tailwind CSS IntelliSense with the `cva` function, complex regular expressions were required, but with the update, `classFunctions` have become available.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md).
- [x] Follow the [Style Guide](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md#style-guide).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
