### PR TITLE
fix: types field should appear first in the exports section

### DIFF
--- a/packages/cva/package.json
+++ b/packages/cva/package.json
@@ -21,8 +21,8 @@
   "license": "Apache-2.0",
   "author": "Joe Bell (https://joebell.co.uk)",
   "exports": {
-    "import": "./src/index.ts",
-    "types": "./src/index.ts"
+    "types": "./src/index.ts",
+    "import": "./src/index.ts"
   },
   "main": "src/index.ts",
   "module": "src/index.ts",
@@ -68,9 +68,9 @@
   },
   "publishConfig": {
     "exports": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.js"
     },
     "main": "dist/index.js",
     "module": "dist/index.mjs",


### PR DESCRIPTION
### Description

The types field should appear first in the exports section.

https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/docs/problems/FallbackCondition.md

> Import resolved to types through a conditional package.json export, but only after failing to resolve through an earlier condition. This behavior is a [TypeScript bug](https://github.com/microsoft/TypeScript/issues/50762). It may misrepresent the runtime behavior of this import and should not be relied upon.

Lint: https://arethetypeswrong.github.io/?p=cva%401.0.0-beta.3

Close #https://github.com/joe-bell/cva/issues/340
Resolve https://github.com/rolldown/tsdown/issues/238

---

### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md).
- [x] Follow the [Style Guide](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md#style-guide).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
