### PR TITLE
Export `ConfigSchema` type

### DIFF
--- a/packages/class-variance-authority/src/index.ts
+++ b/packages/class-variance-authority/src/index.ts
@@ -41,7 +41,7 @@ export const cx = clsx;
 /* cva
   ============================================ */
 
-type ConfigSchema = Record<string, Record<string, ClassValue>>;
+export type ConfigSchema = Record<string, Record<string, ClassValue>>;
 
 type ConfigVariants<T extends ConfigSchema> = {
   [Variant in keyof T]?: StringToBoolean<keyof T[Variant]> | null | undefined;


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

In light of https://github.com/joe-bell/cva/discussions/146, I want to extract the config to use in documentation (e.g. Storybook). Until https://github.com/joe-bell/cva/pull/333 is merged, the only workaround is to declare the config separately to reuse the variants. However, by doing so we lose the type safety of the config.
I'd like to be able to verify that the variants config satisfies the expected `ConfigSchema` type, but this type is not exported. Currently, trying to extract the `ConfigSchema` type using `NonNullable<Parameters<typeof cva>[1]>['variants']` results in `never`, therefore rendering it impossible to achieve type safety in this workaround.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

Somewhat related to https://github.com/joe-bell/cva/pull/271

---

### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md).
- [x] Follow the [Style Guide](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md#style-guide).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
