### PR TITLE
docs: add Deno to installation instructions

### DIFF
--- a/docs/beta/src/content/docs/getting-started/installation.mdx
+++ b/docs/beta/src/content/docs/getting-started/installation.mdx
@@ -41,6 +41,13 @@ For stable documentation, please visit [cva.style](https://cva.style).
     ```
 
   </TabItem>
+  <TabItem label="deno">
+
+    ```sh
+    deno add cva@beta
+    ```
+
+  </TabItem>
 </Tabs>
 
 ## Tailwind CSS

--- a/docs/latest/pages/docs/getting-started/installation.mdx
+++ b/docs/latest/pages/docs/getting-started/installation.mdx
@@ -5,7 +5,7 @@ import { Carbon } from "../../../components/Carbon";
 
 <Carbon />
 
-<Tabs items={["pnpm", "npm", "yarn", "bun"]}>
+<Tabs items={["pnpm", "npm", "yarn", "bun", "deno"]}>
   <Tab>
 
     ```sh
@@ -30,6 +30,11 @@ import { Carbon } from "../../../components/Carbon";
   <Tab>
     ```sh
     bun add class-variance-authority
+    ```
+  </Tab>
+  <Tab>
+    ```sh
+    deno add class-variance-authority
     ```
   </Tab>
 </Tabs>


### PR DESCRIPTION
### Description

👋 Bartek from the Deno team here. This adds a Deno tab to the Installation page's package-manager `<Tabs>`, alongside pnpm / npm / yarn / bun. Since Deno is a drop-in replacement for npm these days, `deno add class-variance-authority` mirrors the others.

### Additional context

Docs-only, edits the current Nextra docs (`docs/latest/.../installation.mdx`). Happy to also update the beta (Astro Starlight) docs if you'd like.

### What is the purpose of this pull request?

- [x] Documentation update

### Before submitting the PR, please make sure you do the following

- [x] Read the Contributing Guidelines.
- [x] Check that there isn't already a PR that solves the problem the same way.
- [x] Provide a description in this PR that addresses what the PR is solving.

_Disclosure: I work on Deno, so I have an interest here. The goal is parity with the package managers you already list, not promotion. This PR was prepared with AI assistance under human supervision: I review every change myself and personally respond to any comments or review feedback._
