### PR TITLE
Migrate tailwind-merge and clsx to cnfast for performance improvements

### DIFF
--- a/docs/beta/src/content/docs/getting-started/installation.mdx
+++ b/docs/beta/src/content/docs/getting-started/installation.mdx
@@ -132,16 +132,16 @@ You can enable autocompletion inside `cva` using the steps below:
 
 ### Handling Style Conflicts
 
-If you want to merge Tailwind CSS classes without conflicts, you may wish to [roll-your-own `cva`](../api-reference#defineconfig) with the [`tailwind-merge`](https://github.com/dcastil/tailwind-merge) package:
+If you want to merge Tailwind CSS classes without conflicts, you may wish to [roll-your-own `cva`](../api-reference#defineconfig) with the [`cnfast`](https://github.com/aidenybai/cnfast) package:
 
 <details>
 
-<summary>Example with tailwind-merge</summary>
+<summary>Example with cnfast</summary>
 
 ```ts
 // cva.config.ts
 import { defineConfig } from "cva";
-import { twMerge } from "tailwind-merge";
+import { twMerge } from "cnfast"; // or "tailwind-merge"
 
 export const { cva, cx, compose } = defineConfig({
   hooks: {

--- a/docs/latest/pages/docs/getting-started/installation.mdx
+++ b/docs/latest/pages/docs/getting-started/installation.mdx
@@ -142,7 +142,7 @@ You can enable autocompletion inside `cva` using the steps below:
 
 Although `cva`'s API is designed to help you avoid styling conflicts, there's still a small margin of error.
 
-If you're keen to lift that burden altogether, check out the wonderful [`tailwind-merge`](https://github.com/dcastil/tailwind-merge) package.
+If you're keen to lift that burden altogether, you can use [`cnfast`](https://github.com/aidenybai/cnfast) based on the wonderful [`tailwind-merge`](https://github.com/dcastil/tailwind-merge) package.
 
 For bulletproof components, wrap your `cva` component with `twMerge`.
 
@@ -152,7 +152,7 @@ For bulletproof components, wrap your `cva` component with `twMerge`.
 
 ```ts
 import { cva, type VariantProps } from "class-variance-authority";
-import { twMerge } from "tailwind-merge";
+import { twMerge } from "cnfast"; // or "tailwind-merge"
 
 const buttonVariants = cva(["your", "base", "classes"], {
   variants: {

--- a/packages/class-variance-authority/package.json
+++ b/packages/class-variance-authority/package.json
@@ -45,7 +45,7 @@
     "prepublishOnly": "pnpm build"
   },
   "dependencies": {
-    "clsx": "^2.1.1"
+    "cnfast": "^0.0.8"
   },
   "devDependencies": {
     "@size-limit/preset-small-lib": "^12.1.0",

--- a/packages/class-variance-authority/src/index.ts
+++ b/packages/class-variance-authority/src/index.ts
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-import { clsx } from "clsx";
+import { clsx } from "cnfast";
 
 import type {
   ClassProp,

--- a/packages/class-variance-authority/src/types.ts
+++ b/packages/class-variance-authority/src/types.ts
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-import type * as CLSX from "clsx";
+import type * as CLSX from "cnfast";
 
 export type ClassPropKey = "class" | "className";
 

--- a/packages/cva/package.json
+++ b/packages/cva/package.json
@@ -43,7 +43,7 @@
     "prepublishOnly": "pnpm build"
   },
   "dependencies": {
-    "clsx": "^2.1.1"
+    "cnfast": "^0.0.8"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "0.18.2",

--- a/packages/cva/src/index.ts
+++ b/packages/cva/src/index.ts
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-import { clsx } from "clsx";
+import { clsx } from "cnfast";
 
 /* Types
   ============================================ */


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR replace `clsx` and `tailwind-merge` by [cnfast](https://github.com/aidenybai/cnfast) that is way much faster while keeping the exact same api.

I made some changes to the documentation, but i think it needs to be more clear about why CVA use this package instead of the two others :)


And btw, thank you for your work, we're using CVA everyday and it's amazing ! <3

### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other (Performance)

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md).
- [x] Follow the [Style Guide](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md#style-guide).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
