### PR TITLE
refactor(docs): replace inline styles with Tailwind v4 utilities

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,21 @@ yarn.
 | `docs`                              | Unified docs site ([cva.style](https://cva.style), Astro Starlight) — stable at the root, beta under `/beta` via [`starlight-versions`](https://starlight-versions.vercel.app) |
 | `examples/beta`, `examples/latest`  | Framework usage examples for each package                                                                                                                                      |
 
+## Docs styling
+
+The `docs` site styles with **Tailwind CSS v4** via Starlight's official
+integration (`@astrojs/starlight-tailwind` + `@tailwindcss/vite`, configured in
+[`docs/astro.config.ts`](./docs/astro.config.ts) and
+[`docs/src/styles/main.css`](./docs/src/styles/main.css)). See Starlight's
+[CSS & Tailwind guide](https://starlight.astro.build/guides/css-and-tailwind/#tailwind-css).
+
+When styling components, use Tailwind v4 utility classes — don't reach for
+inline `style="…"`/`style={{ … }}` attributes or `<style>` tags. Prefer
+variant utilities (e.g. `after:…`, `dark:…`) over scoped CSS, and arbitrary
+values (e.g. `after:bg-[hsl(0,0%,98%)]`) when no token fits. Global styling
+that can't be expressed as utilities belongs in `main.css` (`@apply`, theme
+tokens), not in per-component `<style>` blocks.
+
 ## Contributing
 
 [CONTRIBUTING.md](./CONTRIBUTING.md) is the single source of truth for project

--- a/docs/src/components/carbon.astro
+++ b/docs/src/components/carbon.astro
@@ -9,6 +9,7 @@
     "h-38.5",
     "*:mt-0!",
     "[&+:where(h1,h2,h3,h4,h5,h6)]:mt-4!",
+    "after:absolute after:inset-0 after:-z-[1] after:block after:h-32.5 after:max-w-100 after:border after:border-[hsl(0,0%,92%)] after:bg-[hsl(0,0%,98%)] after:content-['']",
   ]}
 >
   <script
@@ -18,17 +19,3 @@
     src="//cdn.carbonads.com/carbon.js?serve=CW7IC2QE&placement=cvastyle&format=responsive"
     id="_carbonads_js"></script>
 </div>
-
-<style scoped>
-  #carbon-container::after {
-    content: "";
-    position: absolute;
-    display: block;
-    inset: 0;
-    height: 8.125rem;
-    max-width: 25rem;
-    background-color: hsl(0, 0%, 98%);
-    border: solid 1px hsl(0, 0%, 92%);
-    z-index: -1;
-  }
-</style>

--- a/docs/src/components/site-title.astro
+++ b/docs/src/components/site-title.astro
@@ -6,6 +6,6 @@ import Default from "@astrojs/starlight/components/SiteTitle.astro";
 const isBeta = Astro.url.pathname.startsWith("/beta");
 ---
 
-<div style="display: contents" data-version={isBeta ? "beta" : "latest"}>
+<div class="contents" data-version={isBeta ? "beta" : "latest"}>
   <Default {...Astro.props}><slot /></Default>
 </div>

--- a/docs/src/components/stackblitz.astro
+++ b/docs/src/components/stackblitz.astro
@@ -19,7 +19,7 @@ invariant(file, "No file specified");
     View on GitHub <span aria-label="External">↗</span>
   </a>
   <iframe
-    style={{ aspectRatio: 1 / 1, width: "100%" }}
+    class="aspect-square w-full"
     src={`https://stackblitz.com/github/joe-bell/cva/tree/${branch}/${dir}?embed=1&file=${file}&hideNavigation=1&view=preview`}
   ></iframe>
 </div>


### PR DESCRIPTION
Convert the remaining raw styles in the docs components to Tailwind v4
utility classes, matching the rest of the site:

- site-title: style="display: contents" -> class="contents"
- stackblitz: style={{ aspectRatio, width }} -> aspect-square w-full
- carbon: scoped <style> ::after block -> after:* utilities

Document the Tailwind v4 styling convention (and link Starlight's CSS &
Tailwind guide) in AGENTS.md to prevent inline styles creeping back in.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BZi8QtggiXbNMv5PC4B6wQ