### PR TITLE
fix(docs): replace deprecated Zod 4 APIs in tutorials schema

### DIFF
--- a/docs/src/content.config.ts
+++ b/docs/src/content.config.ts
@@ -28,15 +28,9 @@ export const collections = {
       });
 
       return z.discriminatedUnion("format", [
-        common.merge(
-          z.object({ format: z.literal("Audio"), url: z.string().url() }),
-        ),
-        common.merge(
-          z.object({ format: z.literal("Article"), url: z.string().url() }),
-        ),
-        common.merge(
-          z.object({ format: z.literal("YouTube"), youtubeId: z.string() }),
-        ),
+        common.extend({ format: z.literal("Audio"), url: z.url() }),
+        common.extend({ format: z.literal("Article"), url: z.url() }),
+        common.extend({ format: z.literal("YouTube"), youtubeId: z.string() }),
       ]);
     },
   }),

--- a/docs/src/content/docs/beta/index.mdx
+++ b/docs/src/content/docs/beta/index.mdx
@@ -11,6 +11,7 @@ import { Picture } from "astro:assets";
   height={1080}
   layout="constrained"
   formats={["avif", "webp"]}
+  priority
 />
 
 <br />

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -15,6 +15,7 @@ import { Picture } from "astro:assets";
   height={1080}
   layout="constrained"
   formats={["avif", "webp"]}
+  priority
 />
 
 <br />

--- a/docs/src/content/docs/tutorials.mdx
+++ b/docs/src/content/docs/tutorials.mdx
@@ -3,49 +3,26 @@ title: Tutorials
 ---
 
 import Carbon from "../../components/carbon.astro";
+import TutorialList from "../../components/tutorial-list.astro";
 
 <Carbon />
 
+## YouTube
+
+<TutorialList format="YouTube" />
+
 ## Audio
 
-- [JS Party – Episode #277](https://changelog.com/jsparty/277)
+<TutorialList format="Audio" />
 
-## Video
+## Articles
 
-### mewtru
+<TutorialList format="Article" />
 
-<iframe
-  src="https://www.youtube.com/embed/T-Zv73yZ_QI"
-  title="YouTube video player"
-  frameBorder="0"
-  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-  allowFullScreen
-></iframe>
+<br />
 
-<iframe
-  src="https://www.youtube.com/embed/kTSwLLFa3WM"
-  title="YouTube video player"
-  frameBorder="0"
-  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-  allowFullScreen
-></iframe>
+:::tip[Created a tutorial?]
 
-### frontendfyi
+[Feel free to add your content here](https://github.com/joe-bell/cva/tree/main/docs/src/content/tutorials)
 
-<iframe
-  src="https://www.youtube.com/embed/B6FrDu2Qbt0"
-  title="YouTube video player"
-  frameBorder="0"
-  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-  allowFullScreen
-></iframe>
-
-### Josh tried coding
-
-<iframe
-  src="https://www.youtube.com/embed/eXRlVpw1SIQ"
-  title="YouTube video player"
-  frameBorder="0"
-  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-  allowFullScreen
-></iframe>
+:::


### PR DESCRIPTION
### Description

A few related docs maintenance changes:

- **Fix deprecated Zod 4 APIs in the tutorials schema.** Astro 7 bundles Zod 4, which deprecates `.merge()` and `z.string().url()`. The tutorials content collection schema now uses `.extend()` and `z.url()` so `astro check` reports no hints during the docs build.
- **Align the latest tutorials page with the beta one.** The latest `tutorials.mdx` now mirrors the beta page's content and components (the `TutorialList`-driven YouTube/Audio/Articles sections plus the "Created a tutorial?" callout), with only the component import paths adjusted for the page's depth.
- **Mark the home page hero image as `priority`.** Added the `priority` prop to the `Picture` component on both the latest and beta index pages so the above-the-fold hero image is eagerly loaded.

### Additional context

Verified with `astro check` (0 errors/warnings/hints) and a full `astro build` on each change.

---

### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md).
- [x] Follow the [Style Guide](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md#style-guide).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UqtRQSjuAhgNt8LKbtt2AJ