### PR TITLE
docs: document Cloudflare Workers Builds deployment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,4 +63,5 @@ Agent-specific notes:
   fire in your environment, run it manually against the staged changes with
   `pnpm lint-staged`.
 - **Never hard-wrap prose.** In Markdown (`.md` / `.mdx`), code comments, and commit bodies, write each paragraph as one unbroken line and let the editor soft-wrap it — don't insert manual newlines to keep lines short. Prettier defaults to `proseWrap: "preserve"`, so it won't reflow prose for you, and any hard wraps get committed verbatim as noisy diffs.
+- The `docs` site deploys via Cloudflare Workers Builds, and its build watch paths are configured in the Cloudflare dashboard UI (not `wrangler.jsonc`). See [Deployment](./docs/README.md#-deployment) in the docs README before changing how docs builds are scoped.
 - To verify an `examples/` change in a real StackBlitz WebContainer before merging, open it from GitHub against your branch: `https://stackblitz.com/github/joe-bell/cva/tree/<branch>/<dir>`. Branch names containing slashes (e.g. `claude/my-feature`) resolve fine — StackBlitz parses them correctly against the trailing path, so no slash-free branch is needed.

--- a/README.md
+++ b/README.md
@@ -40,3 +40,5 @@ Visit [**cva.style**](https://cva.style) to get started.
 ## License
 
 [Apache-2.0 License](/LICENSE) © [Joe Bell](https://joebell.studio)
+
+<!-- temp: build-watch-paths test — root .md should NOT trigger a docs build (remove me) -->

--- a/README.md
+++ b/README.md
@@ -40,5 +40,3 @@ Visit [**cva.style**](https://cva.style) to get started.
 ## License
 
 [Apache-2.0 License](/LICENSE) © [Joe Bell](https://joebell.studio)
-
-<!-- temp: build-watch-paths test — root .md should NOT trigger a docs build (remove me) -->

--- a/docs/README.md
+++ b/docs/README.md
@@ -49,17 +49,17 @@ All commands are run from the root of the project, from a terminal:
 
 ## 🚀 Deployment
 
-This site deploys via [Cloudflare Workers Builds](https://developers.cloudflare.com/workers/ci-cd/builds/), which rebuilds on every push to the connected repo. Because this is a monorepo, builds are scoped with [build watch paths](https://developers.cloudflare.com/pages/configuration/build-watch-paths/) so unrelated changes don't redeploy the site. These paths are **configured in the Cloudflare dashboard UI** (Settings → Build → Build watch paths), as per the Cloudflare docs — there is no Wrangler config field for them, so they do **not** live in [`wrangler.jsonc`](./wrangler.jsonc). Paths are matched against full, repo-root-relative paths from the push event, independent of the worker's `docs/` root directory.
+Deployed via [Cloudflare Workers Builds](https://developers.cloudflare.com/workers/ci-cd/builds/). Builds are scoped with [build watch paths](https://developers.cloudflare.com/pages/configuration/build-watch-paths/) set in the Cloudflare dashboard (**Settings → Build → Build watch paths**); there's no `wrangler.jsonc` equivalent. Paths are repo-root-relative, independent of the worker's `docs/` root.
 
-Current **include paths** (exclude paths are empty):
+Include paths (excludes are empty):
 
-- `docs/*` — the site source
-- `packages/cva/*` — the only workspace package the docs depend on
-- `.config/*` — shared tooling config
-- `package.json`, `tsconfig.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`, `.prettierrc.json` — root files that match the include rule (have an extension, aren't `.md`)
-- `.nvmrc` — a deliberate exception to the "skip extensionless root files" rule, since the build reads it for the Node version
+- `docs/*`
+- `packages/cva/*`
+- `.config/*`
+- `package.json`, `tsconfig.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`, `.prettierrc.json`
+- `.nvmrc` — Node version; the one extensionless file we watch
 
-A `*` matches across `/`, so a trailing-`*` entry like `docs/*` also covers nested files. Root `.md` files (e.g. `README.md`) and the other extensionless root files (e.g. `LICENSE`, `.gitignore`) are intentionally omitted so prose-only changes don't trigger a deploy. Cloudflare also force-builds regardless of these paths when a push has 0 changes, 3000+ changed files, or 20+ commits.
+`*` matches across `/`, so `docs/*` covers nested files. Root `.md` files and other extensionless files (`LICENSE`, `.gitignore`) are excluded, so prose-only changes don't redeploy.
 
 ## 👀 Want to learn more?
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,6 +47,20 @@ All commands are run from the root of the project, from a terminal:
 | `npm run astro ...`       | Run CLI commands like `astro add`, `astro check` |
 | `npm run astro -- --help` | Get help using the Astro CLI                     |
 
+## 🚀 Deployment
+
+This site deploys via [Cloudflare Workers Builds](https://developers.cloudflare.com/workers/ci-cd/builds/), which rebuilds on every push to the connected repo. Because this is a monorepo, builds are scoped with [build watch paths](https://developers.cloudflare.com/pages/configuration/build-watch-paths/) so unrelated changes don't redeploy the site. These paths are **configured in the Cloudflare dashboard UI** (Settings → Build → Build watch paths), as per the Cloudflare docs — there is no Wrangler config field for them, so they do **not** live in [`wrangler.jsonc`](./wrangler.jsonc). Paths are matched against full, repo-root-relative paths from the push event, independent of the worker's `docs/` root directory.
+
+Current **include paths** (exclude paths are empty):
+
+- `docs/*` — the site source
+- `packages/cva/*` — the only workspace package the docs depend on
+- `.config/*` — shared tooling config
+- `package.json`, `tsconfig.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`, `.prettierrc.json` — root files that match the include rule (have an extension, aren't `.md`)
+- `.nvmrc` — a deliberate exception to the "skip extensionless root files" rule, since the build reads it for the Node version
+
+A `*` matches across `/`, so a trailing-`*` entry like `docs/*` also covers nested files. Root `.md` files (e.g. `README.md`) and the other extensionless root files (e.g. `LICENSE`, `.gitignore`) are intentionally omitted so prose-only changes don't trigger a deploy. Cloudflare also force-builds regardless of these paths when a push has 0 changes, 3000+ changed files, or 20+ commits.
+
 ## 👀 Want to learn more?
 
 Check out [Starlight’s docs](https://starlight.astro.build/), read [the Astro documentation](https://docs.astro.build), or jump into the [Astro Discord server](https://astro.build/chat).


### PR DESCRIPTION
### Description

This PR documents the deployment configuration for the `docs` site, which uses Cloudflare Workers Builds with build watch paths to prevent unnecessary rebuilds in this monorepo when unrelated files change.

The new "🚀 Deployment" section in `docs/README.md` explains:
- How the site deploys via Cloudflare Workers Builds
- Why build watch paths are configured in the Cloudflare dashboard UI (not in `wrangler.jsonc`)
- The specific include paths that trigger rebuilds (docs source, the `cva` package dependency, shared config, and root files)
- Why certain files are intentionally excluded (prose-only changes, extensionless root files except `.nvmrc`)
- How path matching works with wildcards and Cloudflare's force-build conditions

Also adds a note to `AGENTS.md` directing contributors to this documentation before making changes that affect how docs builds are scoped.

### Additional context

This is purely documentation — no build configuration or deployment behavior is being changed. The documentation captures the current setup to help contributors understand the deployment constraints and avoid accidentally breaking the build watch path configuration.

---

### What is the purpose of this pull request?

- [x] Documentation update
- [ ] Bug fix
- [ ] New Feature
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md).
- [x] Follow the [Style Guide](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md#style-guide).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving.

https://claude.ai/code/session_01Bfg43pooBCTaA2jToaKFzF