### PR TITLE
Annotate lint-staged config with Configuration type

### DIFF
--- a/.config/lint-staged.config.mjs
+++ b/.config/lint-staged.config.mjs
@@ -1,5 +1,6 @@
 import { dirname } from "node:path";
 
+/** @type {import("lint-staged").Configuration} */
 export default {
   "*.{astro,js,jsx,svelte,ts,tsx,vue}": (filenames) => [
     "pnpm run --filter '!.' --parallel check",


### PR DESCRIPTION
### Description

Adds a `/** @type {import("lint-staged").Configuration} */` JSDoc annotation to the lint-staged config (`.config/lint-staged.config.mjs`). This gives editors type-checking and autocompletion for the config object — catching typos in glob keys or malformed task values — without any runtime change.

### Additional context

Purely a type annotation; the exported config is unchanged.

---

### What is the purpose of this pull request?

- [x] Other (developer tooling / type-safety improvement)

### Before submitting the PR, please make sure you do the following

- [x] Read the Contributing Guidelines.
- [x] Follow the Style Guide.
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016NuQN4JQUUdRxcbTkkyrkR)_