### PR TITLE
Clarify pre-commit hook policy and setup for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,13 +113,22 @@ goals, setup, scripts, and conventions (Conventional Commits, Prettier,
 TypeScript) — follow it rather than duplicating its guidance here. All
 participation is governed by the [Code of Conduct](./CODE_OF_CONDUCT.md).
 
+### Commit workflow: the pre-commit hook is mandatory
+
+This is policy, not a suggestion. Read it before every commit; it applies to every agent, every session, and every commit, with no exceptions.
+
+1. **Every commit MUST go through the repo's pre-commit hook** — [`.github/hooks/pre-commit`](./.github/hooks/pre-commit), wired up via `git config core.hooksPath .github/hooks` (registered by the `prepare:hooks` script whenever `pnpm install` runs). It runs `pnpm lint-staged` against the staged files (type check, Prettier, syncpack, skills lint — config in [`.config/lint-staged.config.mjs`](./.config/lint-staged.config.mjs)). Committing with `git commit --no-verify` (or `-n`), unsetting or redirecting `core.hooksPath`, or any equivalent bypass is **forbidden**.
+2. **A silently-missing hook is never a pass.** Verify the hook actually fired: a real run prints lint-staged task output (e.g. `Running tasks for staged files...`) between your `git commit` invocation and the commit summary — silence means it did not run. To check the wiring directly, `git config core.hooksPath` must print `.github/hooks`; on a fresh clone before `pnpm install` it is **unset**, and git then commits without running any checks at all.
+3. **If the hook did not run for any reason** (fresh clone before install, `core.hooksPath` unset, `pnpm`/`lint-staged` missing from `PATH`), run the underlying check manually against the staged files before committing: bootstrap the toolchain first if needed (`nvm use && corepack enable && pnpm install`), then run `pnpm lint-staged`.
+4. **Self-repair is mandatory, in the same session.** Don't stop at the manual run — fix the wiring so the hook fires again: re-run `pnpm install` (its `prepare:hooks` step re-registers the hooks path), verify `git config core.hooksPath` prints `.github/hooks`, confirm the next commit visibly shows the hook's lint-staged output, and mention the repair in your summary.
+5. **If the repair itself fails, report it loudly** — state exactly what is broken and what you tried in your summary — instead of committing around it. A manual `pnpm lint-staged` run is an emergency stopgap for a single commit while the hook is being repaired, never an alternative workflow.
+
 Agent-specific notes:
 
 - **Never expose private repositories.** This is a public repo: anything you write here is published. Never reference the owner's (or anyone's) private repositories — no repo names, URLs, or file paths — in code, docs, commit messages, PR titles/descriptions, issues, or review comments. If work is ported or adapted from a private source, describe it neutrally ("hand-maintained", "vendored") without naming or linking the source. This applies to every agent and every session, with no exceptions.
 - This project uses `nvm` to manage Node.js versions, so prefix commands with
   `nvm use` where necessary. If you're Zed's agent you likely **won't** need
   to.
-- A `pre-commit` hook runs `lint-staged` (type check, Prettier, syncpack, skills lint) against staged changes. Make sure it runs before pushing — if it doesn't fire in your environment, run it manually against the staged changes with `pnpm lint-staged`.
 - **Formatting is part of the change, not a follow-up.** Before staging, run Prettier over the files you touched (`pnpm prettier --write <files>`) and stage the formatted result so it lands in the _same_ commit. Then confirm `git status` is clean. Never push a separate "prettier wrap"/formatting-only fixup commit to tidy up after yourself — that's noise, and it means the original commit was incomplete.
 - **Never hard-wrap Markdown prose.** In Markdown (`.md` / `.mdx`) only, write each paragraph as one unbroken line and let the editor soft-wrap it — don't insert manual newlines to keep lines short. Prettier defaults to `proseWrap: "preserve"`, so it won't reflow Markdown prose for you, and any hard wraps get committed verbatim as noisy diffs. Everywhere else — code comments and commit bodies — do hard-wrap, keeping lines within Prettier's `printWidth` (`80`, set in [`.prettierrc.json`](./.prettierrc.json)).
 - The `docs` site deploys via Cloudflare Workers Builds, and its build watch paths are configured in the Cloudflare dashboard UI (not `wrangler.jsonc`). See [Deployment](./docs/README.md#-deployment) in the docs README before changing how docs builds are scoped.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,7 @@ focused:
    ```sh
    pnpm i
    ```
+   Installing also registers the git pre-commit hook: the `prepare:hooks` script sets `core.hooksPath` to [`.github/hooks`](./.github/hooks), whose `pre-commit` runs `pnpm lint-staged` against your staged files on every commit. Don't bypass it (`--no-verify`) — if it didn't fire, re-run `pnpm i` and check `git config core.hooksPath` prints `.github/hooks`.
 5. Voilà, you're ready to go!
 
 ### Node.js versions
@@ -62,6 +63,7 @@ Run these from the repo root:
 - `pnpm prettier --check .` – checks formatting (`--write` to fix)
 - `pnpm syncpack:lint` – checks dependency-version consistency (`pnpm syncpack:fix` to fix)
 - `pnpm lint:skills` – validates the agent skills in `.agents/skills` (`skill-check`, strict mode)
+- `pnpm lint-staged` – runs the pre-commit checks against currently staged files (exactly what the pre-commit hook runs)
 
 To scope a command to a single package, use a pnpm filter, e.g. `pnpm --filter cva test`.
 


### PR DESCRIPTION
### Description

Expands and clarifies the mandatory pre-commit hook workflow for agents in `AGENTS.md`, and adds setup guidance to `CONTRIBUTING.md`. The changes emphasize that the hook is non-negotiable policy, not optional, and provide explicit steps to verify it's wired correctly, detect when it fails silently, and repair it if needed.

**Key additions:**

- **`AGENTS.md`**: New "Commit workflow: the pre-commit hook is mandatory" section with five numbered rules covering:
  - Requirement that every commit runs the hook (no `--no-verify` bypasses)
  - How to verify the hook actually fired (look for lint-staged output)
  - Manual fallback if the hook is missing (bootstrap toolchain, run `pnpm lint-staged`)
  - Self-repair obligation (re-run `pnpm install`, verify `core.hooksPath`, confirm next commit shows hook output)
  - Escalation: report failures loudly instead of committing around them
- **`CONTRIBUTING.md`**: 
  - Clarifies that `pnpm install` registers the hook via the `prepare:hooks` script
  - Warns against `--no-verify` and explains how to detect/fix a missing hook
  - Documents `pnpm lint-staged` as the command agents can run manually to replicate pre-commit checks

Removes the old, brief pre-commit note from the agent-specific section since it's now covered in detail above.

### Additional context

This addresses the risk of agents bypassing or unknowingly skipping the pre-commit hook, which runs critical checks (type check, Prettier, syncpack, skills lint). The new guidance makes it clear this is mandatory policy with no exceptions, provides concrete verification steps, and ensures agents can self-repair if the hook setup breaks in their environment.

---

### What is the purpose of this pull request?

- [x] Documentation update
- [ ] Bug fix
- [ ] New Feature
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md).
- [x] Follow the [Style Guide](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md#style-guide).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving.

https://claude.ai/code/session_01YLgksyv6x2k2f1gnV3cUKa