### PR TITLE
feat(cva): introduce internal variants

### DIFF
--- a/docs/src/content/docs/beta/api-reference.mdx
+++ b/docs/src/content/docs/beta/api-reference.mdx
@@ -17,7 +17,7 @@ const component = cva(options);
 
 1. `options`
    - `base`: the base class name (`string`, `string[]` or other [`clsx` value](https://github.com/lukeed/clsx#input))
-   - `variants`: your variants schema
+   - `variants`: your variants schema. A variant name prefixed with `_` is [internal](/beta/getting-started/variants#internal-variants): hidden from the component's props type and from `getSchema`, but still settable via `defaultVariants` and matchable in `compoundVariants`
    - `compoundVariants`: variants based on a combination of previously defined variants
    - `defaultVariants`: set default values for previously defined variants
    - `composes`: shallow merge one or more other `cva` components into this one, as a single component or an array (see [Composing Components](/beta/getting-started/composing-components))
@@ -76,7 +76,7 @@ getSchema(button);
 // }
 ```
 
-`getSchema` omits a variant that has no values (e.g. `variants: { empty: {} }`).
+`getSchema` omits a variant that has no values (e.g. `variants: { empty: {} }`) and any [internal](/beta/getting-started/variants#internal-variants) (`_`-prefixed) variant.
 
 ### Parameters
 

--- a/docs/src/content/docs/beta/api-reference.mdx
+++ b/docs/src/content/docs/beta/api-reference.mdx
@@ -17,7 +17,7 @@ const component = cva(options);
 
 1. `options`
    - `base`: the base class name (`string`, `string[]` or other [`clsx` value](https://github.com/lukeed/clsx#input))
-   - `variants`: your variants schema. Names prefixed with `_` are [internal](/beta/getting-started/variants#internal-variants)
+   - `variants`: your [variants schema](/beta/getting-started/variants)
    - `compoundVariants`: variants based on a combination of previously defined variants
    - `defaultVariants`: set default values for previously defined variants
    - `composes`: shallow merge one or more other `cva` components into this one, as a single component or an array (see [Composing Components](/beta/getting-started/composing-components))
@@ -76,7 +76,7 @@ getSchema(button);
 // }
 ```
 
-`getSchema` omits a variant that has no values (e.g. `variants: { empty: {} }`) and any [internal](/beta/getting-started/variants#internal-variants) (`_`-prefixed) variant.
+`getSchema` omits [internal variants](/beta/getting-started/variants#internal-variants) or variants that have no values (e.g. `variants: { empty: {} }`).
 
 ### Parameters
 

--- a/docs/src/content/docs/beta/api-reference.mdx
+++ b/docs/src/content/docs/beta/api-reference.mdx
@@ -17,7 +17,7 @@ const component = cva(options);
 
 1. `options`
    - `base`: the base class name (`string`, `string[]` or other [`clsx` value](https://github.com/lukeed/clsx#input))
-   - `variants`: your variants schema. A variant name prefixed with `_` is [internal](/beta/getting-started/variants#internal-variants): omitted from `VariantProps` and from `getSchema`, but still accepted by the component and settable via `defaultVariants`/`compoundVariants`
+   - `variants`: your variants schema. Names prefixed with `_` are [internal](/beta/getting-started/variants#internal-variants)
    - `compoundVariants`: variants based on a combination of previously defined variants
    - `defaultVariants`: set default values for previously defined variants
    - `composes`: shallow merge one or more other `cva` components into this one, as a single component or an array (see [Composing Components](/beta/getting-started/composing-components))

--- a/docs/src/content/docs/beta/api-reference.mdx
+++ b/docs/src/content/docs/beta/api-reference.mdx
@@ -17,7 +17,7 @@ const component = cva(options);
 
 1. `options`
    - `base`: the base class name (`string`, `string[]` or other [`clsx` value](https://github.com/lukeed/clsx#input))
-   - `variants`: your variants schema. A variant name prefixed with `_` is [internal](/beta/getting-started/variants#internal-variants): hidden from the component's props type and from `getSchema`, but still settable via `defaultVariants` and matchable in `compoundVariants`
+   - `variants`: your variants schema. A variant name prefixed with `_` is [internal](/beta/getting-started/variants#internal-variants): omitted from `VariantProps` and from `getSchema`, but still accepted by the component and settable via `defaultVariants`/`compoundVariants`
    - `compoundVariants`: variants based on a combination of previously defined variants
    - `defaultVariants`: set default values for previously defined variants
    - `composes`: shallow merge one or more other `cva` components into this one, as a single component or an array (see [Composing Components](/beta/getting-started/composing-components))

--- a/docs/src/content/docs/beta/getting-started/typescript.mdx
+++ b/docs/src/content/docs/beta/getting-started/typescript.mdx
@@ -5,7 +5,9 @@ description: Extract variant types with VariantProps and require specific varian
 
 ## Extracting variant types
 
-`cva` offers the `VariantProps` helper to extract variant types. `VariantProps` omits variant names prefixed with `_`; see [Internal variants](/beta/getting-started/variants#internal-variants).
+`cva` offers the `VariantProps` helper to extract variant types.
+
+`VariantProps` omits variant names prefixed with `_`; see [Internal variants](/beta/getting-started/variants#internal-variants).
 
 ```ts
 // components/button.ts

--- a/docs/src/content/docs/beta/getting-started/typescript.mdx
+++ b/docs/src/content/docs/beta/getting-started/typescript.mdx
@@ -5,7 +5,7 @@ description: Extract variant types with VariantProps and require specific varian
 
 ## Extracting variant types
 
-`cva` offers the `VariantProps` helper to extract variant types
+`cva` offers the `VariantProps` helper to extract variant types. `VariantProps` omits variant names prefixed with `_`; see [Internal variants](/beta/getting-started/variants#internal-variants).
 
 ```ts
 // components/button.ts

--- a/docs/src/content/docs/beta/getting-started/utilities.mdx
+++ b/docs/src/content/docs/beta/getting-started/utilities.mdx
@@ -37,4 +37,6 @@ getSchema(button);
 
 The schema is fully typed: `values` narrows to the variant's literal values, and `defaultValue` only appears when the component declares one.
 
+[Internal variants](/beta/getting-started/variants#internal-variants) (names prefixed with `_`) are left out, since they aren't part of a component's public surface.
+
 For the full signature, see the [API reference](/beta/api-reference#getschema).

--- a/docs/src/content/docs/beta/getting-started/utilities.mdx
+++ b/docs/src/content/docs/beta/getting-started/utilities.mdx
@@ -37,6 +37,6 @@ getSchema(button);
 
 The schema is fully typed: `values` narrows to the variant's literal values, and `defaultValue` only appears when the component declares one.
 
-[Internal variants](/beta/getting-started/variants#internal-variants) (names prefixed with `_`) are left out, since they aren't part of a component's public surface.
+[Internal variants](/beta/getting-started/variants#internal-variants) are omitted.
 
 For the full signature, see the [API reference](/beta/api-reference#getschema).

--- a/docs/src/content/docs/beta/getting-started/variants.mdx
+++ b/docs/src/content/docs/beta/getting-started/variants.mdx
@@ -62,82 +62,6 @@ button({ intent: "secondary", size: "small" });
 // => "rounded border font-semibold border-gray-400 bg-white text-gray-800 hover:bg-gray-100 px-2 py-1 text-sm"
 ```
 
-## Compound variants
-
-Variants that apply when multiple other variant conditions are met.
-
-```ts
-// components/button.ts
-import { cva } from "cva";
-
-const button = cva({
-  base: "…",
-  variants: {
-    intent: { primary: "…", secondary: "…" },
-    size: { small: "…", medium: "…" },
-  },
-  compoundVariants: [
-    // Applied via:
-    //   `button({ intent: "primary", size: "medium" })`
-    {
-      intent: "primary",
-      size: "medium",
-      class: "…",
-    },
-  ],
-});
-```
-
-### Targeting multiple variant conditions
-
-```ts
-// components/button.ts
-import { cva } from "cva";
-
-const button = cva({
-  base: "…",
-  variants: {
-    intent: { primary: "…", secondary: "…" },
-    size: { small: "…", medium: "…" },
-  },
-  compoundVariants: [
-    // Applied via:
-    //   `button({ intent: "primary", size: "medium" })`
-    //     or
-    //   `button({ intent: "secondary", size: "medium" })`
-    {
-      intent: ["primary", "secondary"],
-      size: "medium",
-      class: "…",
-    },
-  ],
-});
-```
-
-## Disabling variants
-
-To disable a variant completely, provide an option with a value of `null`.
-
-If you're stuck on naming, we recommend setting an explicit `"unset"` option ([similar to the CSS keyword](https://developer.mozilla.org/en-US/docs/Web/CSS/unset)).
-
-```ts
-import { cva } from "cva";
-
-const button = cva({
-  base: "button",
-  variants: {
-    intent: {
-      unset: null,
-      primary: "button--primary",
-      secondary: "button--secondary",
-    },
-  },
-});
-
-button({ intent: "unset" });
-// => "button"
-```
-
 ## Internal variants
 
 A variant name prefixed with `_` is treated as internal.
@@ -217,4 +141,80 @@ const card = cva({
 
 card();
 // => "tone-loud loud-local"
+```
+
+## Compound variants
+
+Variants that apply when multiple other variant conditions are met.
+
+```ts
+// components/button.ts
+import { cva } from "cva";
+
+const button = cva({
+  base: "…",
+  variants: {
+    intent: { primary: "…", secondary: "…" },
+    size: { small: "…", medium: "…" },
+  },
+  compoundVariants: [
+    // Applied via:
+    //   `button({ intent: "primary", size: "medium" })`
+    {
+      intent: "primary",
+      size: "medium",
+      class: "…",
+    },
+  ],
+});
+```
+
+### Targeting multiple variant conditions
+
+```ts
+// components/button.ts
+import { cva } from "cva";
+
+const button = cva({
+  base: "…",
+  variants: {
+    intent: { primary: "…", secondary: "…" },
+    size: { small: "…", medium: "…" },
+  },
+  compoundVariants: [
+    // Applied via:
+    //   `button({ intent: "primary", size: "medium" })`
+    //     or
+    //   `button({ intent: "secondary", size: "medium" })`
+    {
+      intent: ["primary", "secondary"],
+      size: "medium",
+      class: "…",
+    },
+  ],
+});
+```
+
+## Disabling variants
+
+To disable a variant completely, provide an option with a value of `null`.
+
+If you're stuck on naming, we recommend setting an explicit `"unset"` option ([similar to the CSS keyword](https://developer.mozilla.org/en-US/docs/Web/CSS/unset)).
+
+```ts
+import { cva } from "cva";
+
+const button = cva({
+  base: "button",
+  variants: {
+    intent: {
+      unset: null,
+      primary: "button--primary",
+      secondary: "button--secondary",
+    },
+  },
+});
+
+button({ intent: "unset" });
+// => "button"
 ```

--- a/docs/src/content/docs/beta/getting-started/variants.mdx
+++ b/docs/src/content/docs/beta/getting-started/variants.mdx
@@ -140,9 +140,7 @@ button({ intent: "unset" });
 
 ## Internal variants
 
-A variant name prefixed with `_` is internal: the component still accepts it, and it's still drivable via `defaultVariants` and matchable in `compoundVariants`, but it's omitted from [`VariantProps`](/beta/getting-started/typescript#extracting-variant-types) and from [`getSchema`](/beta/api-reference#getschema).
-
-Use this for a variant you set inside a component but don't want on its public props: `VariantProps` (the type you spread into a wrapping component's props) drops it, while the `cva` component keeps accepting it directly.
+A variant name prefixed with `_` is internal: the component still accepts it, and it's still settable via `defaultVariants` and matchable in `compoundVariants`, but it's omitted from [`VariantProps`](/beta/getting-started/typescript#extracting-variant-types) and from [`getSchema`](/beta/api-reference#getschema).
 
 ```ts
 import { cva, type VariantProps } from "cva";
@@ -198,10 +196,6 @@ function Button({ active, size, className, ...props }: Props) {
   );
 }
 ```
-
-:::note
-Internal variants are omitted from the derived surface (`VariantProps` and `getSchema`), not from the component itself: the component's own call signature still accepts `_intent`, and its value still resolves into the emitted class list.
-:::
 
 A composed-only internal variant is omitted from the composer's `VariantProps` too. To change its default from the composer, redeclare it locally: the same rule applies to any composed-only variant (see [Extending variants](/beta/getting-started/composing-components#extending-variants)).
 

--- a/docs/src/content/docs/beta/getting-started/variants.mdx
+++ b/docs/src/content/docs/beta/getting-started/variants.mdx
@@ -137,3 +137,62 @@ const button = cva({
 button({ intent: "unset" });
 // => "button"
 ```
+
+## Internal variants
+
+A variant name prefixed with `_` is internal: it's still declarable in `variants`, drivable via `defaultVariants`, and matchable in `compoundVariants`, but hidden from the component's props type and from [`getSchema`](/beta/api-reference#getschema).
+
+Use this for a variant an author drives (state, composition wiring), not one a consumer of the component should set directly.
+
+```ts
+import { cva } from "cva";
+
+const button = cva({
+  base: "button",
+  variants: {
+    _intent: {
+      primary: "button--primary",
+      secondary: "button--secondary",
+    },
+    size: {
+      small: "button--small",
+      medium: "button--medium",
+    },
+  },
+  defaultVariants: {
+    _intent: "primary",
+    size: "medium",
+  },
+});
+
+button({ size: "small" });
+// => "button button--primary button--small"
+
+button({ _intent: "secondary" });
+// Type error: object literal may only specify known properties, and
+// '_intent' does not exist in type '{ size?: "small" | "medium" }'
+```
+
+:::caution
+Hiding is type-level only. `_intent` still resolves at runtime through `defaultVariants` (or a matching `compoundVariants` entry), and an untyped caller, or one that casts around the type, can still set it directly. Internal variants keep a prop out of your typed API; they don't keep it out of the emitted class list.
+:::
+
+A composed-only internal variant is hidden from the composer's props too. To change its default from the composer, redeclare it locally: the same rule applies to any composed-only variant (see [Extending variants](/beta/getting-started/composing-components#extending-variants)).
+
+```ts
+const base = cva({
+  variants: {
+    _tone: { quiet: "tone-quiet", loud: "tone-loud" },
+  },
+  defaultVariants: { _tone: "quiet" },
+});
+
+const card = cva({
+  composes: base,
+  variants: { _tone: { loud: "loud-local" } },
+  defaultVariants: { _tone: "loud" },
+});
+
+card();
+// => "tone-loud loud-local"
+```

--- a/docs/src/content/docs/beta/getting-started/variants.mdx
+++ b/docs/src/content/docs/beta/getting-started/variants.mdx
@@ -66,7 +66,7 @@ button({ intent: "secondary", size: "small" });
 
 A variant name prefixed with `_` is treated as internal.
 
-The component still accepts it, it's still settable via `defaultVariants` and matchable in `compoundVariants`, but it's omitted from [`VariantProps`](/beta/getting-started/typescript#extracting-variant-types) and from [`getSchema`](/beta/api-reference#getschema).
+Internal variants remain available to the component. You can set them via `defaultVariants` and match them in `compoundVariants`. Both [`VariantProps`](/beta/getting-started/typescript#extracting-variant-types) and [`getSchema`](/beta/api-reference#getschema) omit them.
 
 ```ts
 import { cva, type VariantProps } from "cva";
@@ -74,14 +74,8 @@ import { cva, type VariantProps } from "cva";
 const button = cva({
   base: "button",
   variants: {
-    _intent: {
-      primary: "button--primary",
-      secondary: "button--secondary",
-    },
-    size: {
-      small: "button--small",
-      medium: "button--medium",
-    },
+    _intent: { primary: "button--primary", secondary: "button--secondary" },
+    size: { small: "button--small", medium: "button--medium" },
   },
   defaultVariants: {
     _intent: "primary",
@@ -89,11 +83,11 @@ const button = cva({
   },
 });
 
-// `_intent` is omitted from the public props...
+// `_intent` is omitted from the public props.
 type ButtonProps = VariantProps<typeof button>;
 // => { size?: "small" | "medium" | undefined }
 
-// ...but the component still accepts it directly.
+// The component still accepts `_intent` directly.
 button({ _intent: "secondary", size: "small" });
 // => "button button--secondary button--small"
 ```

--- a/docs/src/content/docs/beta/getting-started/variants.mdx
+++ b/docs/src/content/docs/beta/getting-started/variants.mdx
@@ -140,12 +140,12 @@ button({ intent: "unset" });
 
 ## Internal variants
 
-A variant name prefixed with `_` is internal: it's still declarable in `variants`, drivable via `defaultVariants`, and matchable in `compoundVariants`, but hidden from the component's props type and from [`getSchema`](/beta/api-reference#getschema).
+A variant name prefixed with `_` is internal: the component still accepts it, and it's still drivable via `defaultVariants` and matchable in `compoundVariants`, but it's omitted from [`VariantProps`](/beta/getting-started/typescript#extracting-variant-types) and from [`getSchema`](/beta/api-reference#getschema).
 
-Use this for a variant an author drives (state, composition wiring), not one a consumer of the component should set directly.
+Use this for a variant you set inside a component but don't want on its public props: `VariantProps` (the type you spread into a wrapping component's props) drops it, while the `cva` component keeps accepting it directly.
 
 ```ts
-import { cva } from "cva";
+import { cva, type VariantProps } from "cva";
 
 const button = cva({
   base: "button",
@@ -165,19 +165,45 @@ const button = cva({
   },
 });
 
-button({ size: "small" });
-// => "button button--primary button--small"
+// `_intent` is omitted from the public props...
+type ButtonProps = VariantProps<typeof button>;
+// => { size?: "small" | "medium" | undefined }
 
-button({ _intent: "secondary" });
-// Type error: object literal may only specify known properties, and
-// '_intent' does not exist in type '{ size?: "small" | "medium" }'
+// ...but the component still accepts it directly.
+button({ _intent: "secondary", size: "small" });
+// => "button button--secondary button--small"
 ```
 
-:::caution
-Hiding is type-level only. `_intent` still resolves at runtime through `defaultVariants` (or a matching `compoundVariants` entry), and an untyped caller, or one that casts around the type, can still set it directly. Internal variants keep a prop out of your typed API; they don't keep it out of the emitted class list.
+In a React component, extend `VariantProps` for the public props, then set the internal variant yourself:
+
+```tsx
+interface Props
+  extends
+    React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof button> {
+  active?: boolean;
+}
+
+// `_intent` never appears in `Props`, so a consumer can't set it.
+function Button({ active, size, className, ...props }: Props) {
+  return (
+    <button
+      className={button({
+        size,
+        _intent: active ? "primary" : "secondary",
+        class: className,
+      })}
+      {...props}
+    />
+  );
+}
+```
+
+:::note
+Internal variants are omitted from the derived surface (`VariantProps` and `getSchema`), not from the component itself: the component's own call signature still accepts `_intent`, and its value still resolves into the emitted class list.
 :::
 
-A composed-only internal variant is hidden from the composer's props too. To change its default from the composer, redeclare it locally: the same rule applies to any composed-only variant (see [Extending variants](/beta/getting-started/composing-components#extending-variants)).
+A composed-only internal variant is omitted from the composer's `VariantProps` too. To change its default from the composer, redeclare it locally: the same rule applies to any composed-only variant (see [Extending variants](/beta/getting-started/composing-components#extending-variants)).
 
 ```ts
 const base = cva({

--- a/docs/src/content/docs/beta/getting-started/variants.mdx
+++ b/docs/src/content/docs/beta/getting-started/variants.mdx
@@ -140,7 +140,9 @@ button({ intent: "unset" });
 
 ## Internal variants
 
-A variant name prefixed with `_` is internal: the component still accepts it, and it's still settable via `defaultVariants` and matchable in `compoundVariants`, but it's omitted from [`VariantProps`](/beta/getting-started/typescript#extracting-variant-types) and from [`getSchema`](/beta/api-reference#getschema).
+A variant name prefixed with `_` is treated as internal.
+
+The component still accepts it, it's still settable via `defaultVariants` and matchable in `compoundVariants`, but it's omitted from [`VariantProps`](/beta/getting-started/typescript#extracting-variant-types) and from [`getSchema`](/beta/api-reference#getschema).
 
 ```ts
 import { cva, type VariantProps } from "cva";

--- a/docs/src/content/docs/beta/getting-started/whats-new.mdx
+++ b/docs/src/content/docs/beta/getting-started/whats-new.mdx
@@ -25,6 +25,14 @@ This [replaces the `compose` function](#1-compose--composes).
 
 Extract a plain-object schema (variant names, values and defaults) from a `cva` component via the new [`getSchema` utility](/beta/getting-started/utilities). Use it to generate Storybook controls or any other UI that reads a component's variants.
 
+### 4. Internal variants
+
+A variant name prefixed with `_` is now [internal](/beta/getting-started/variants#internal-variants): hidden from the component's props type and from `getSchema`, while still settable via `defaultVariants` and matchable in `compoundVariants`.
+
+:::caution[Breaking change]
+If a component already declared a variant with a leading underscore (`_state`, `_internal`, etc.), that variant now disappears from its prop types and from `getSchema` results. It still resolves at runtime through `defaultVariants` or a matching `compoundVariants` entry, so rename it if your code relied on setting it as a public prop.
+:::
+
 ## Deprecations
 
 ### 1. `compose` → `composes`

--- a/docs/src/content/docs/beta/getting-started/whats-new.mdx
+++ b/docs/src/content/docs/beta/getting-started/whats-new.mdx
@@ -27,10 +27,10 @@ Extract a plain-object schema (variant names, values and defaults) from a `cva` 
 
 ### 4. Internal variants
 
-A variant name prefixed with `_` is now [internal](/beta/getting-started/variants#internal-variants): hidden from the component's props type and from `getSchema`, while still settable via `defaultVariants` and matchable in `compoundVariants`.
+A variant name prefixed with `_` is now [internal](/beta/getting-started/variants#internal-variants): omitted from `VariantProps` and from `getSchema`, so it stays off a wrapping component's public props, while the `cva` component still accepts it and it stays settable via `defaultVariants` and matchable in `compoundVariants`.
 
 :::caution[Breaking change]
-If a component already declared a variant with a leading underscore (`_state`, `_internal`, etc.), that variant now disappears from its prop types and from `getSchema` results. It still resolves at runtime through `defaultVariants` or a matching `compoundVariants` entry, so rename it if your code relied on setting it as a public prop.
+If a component already declared a variant with a leading underscore (`_state`, `_internal`, etc.), that variant now disappears from `VariantProps` and from `getSchema` results. The component still accepts it directly, but rename it if you relied on `VariantProps` exposing it as a public prop.
 :::
 
 ## Deprecations

--- a/docs/src/content/docs/beta/getting-started/whats-new.mdx
+++ b/docs/src/content/docs/beta/getting-started/whats-new.mdx
@@ -27,7 +27,7 @@ Extract a plain-object schema (variant names, values and defaults) from a `cva` 
 
 ### 4. Internal variants
 
-A variant name prefixed with `_` is now [internal](/beta/getting-started/variants#internal-variants): omitted from `VariantProps` and from `getSchema`, so it stays off a wrapping component's public props, while the `cva` component still accepts it and it stays settable via `defaultVariants` and matchable in `compoundVariants`.
+A variant name prefixed with `_` is now [internal](/beta/getting-started/variants#internal-variants). It stays off a wrapping component's public props because `VariantProps` and `getSchema` omit it, while the `cva` component still accepts it.
 
 :::caution[Breaking change]
 If a component already declared a variant with a leading underscore (`_state`, `_internal`, etc.), that variant now disappears from `VariantProps` and from `getSchema` results. The component still accepts it directly, but rename it if you relied on `VariantProps` exposing it as a public prop.

--- a/docs/src/content/docs/beta/getting-started/whats-new.mdx
+++ b/docs/src/content/docs/beta/getting-started/whats-new.mdx
@@ -27,10 +27,10 @@ Extract a plain-object schema (variant names, values and defaults) from a `cva` 
 
 ### 4. Internal variants
 
-A variant name prefixed with `_` is now [internal](/beta/getting-started/variants#internal-variants). It stays off a wrapping component's public props because `VariantProps` and `getSchema` omit it, while the `cva` component still accepts it.
+A variant name prefixed with `_` is now treated as [internal](/beta/getting-started/variants#internal-variants). It stays off a wrapping component's public props because `VariantProps` and `getSchema` omit it, while the `cva` component still accepts it.
 
 :::caution[Breaking change]
-If a component already declared a variant with a leading underscore (`_state`, `_internal`, etc.), that variant now disappears from `VariantProps` and from `getSchema` results. The component still accepts it directly, but rename it if you relied on `VariantProps` exposing it as a public prop.
+If a component already declared a variant with a leading underscore (`_state`, `_internal`, etc.), that variant now disappears from `VariantProps` and from `getSchema` results. The component still accepts it directly, but you'll need to rename it if you exposed it as a public prop.
 :::
 
 ## Deprecations

--- a/packages/cva/src/index.test.ts
+++ b/packages/cva/src/index.test.ts
@@ -99,6 +99,38 @@ describe("compose", () => {
       }),
     ).toBe("shadow-md gap-3 adhoc-class");
   });
+
+  test("should accept internal variant props", () => {
+    const base = cva({
+      variants: {
+        _tone: {
+          quiet: "tone-quiet",
+          loud: "tone-loud",
+        },
+      },
+      defaultVariants: { _tone: "quiet" },
+    });
+
+    const stack = cva({
+      variants: {
+        gap: {
+          1: "gap-1",
+          2: "gap-2",
+        },
+      },
+      defaultVariants: { gap: 1 },
+    });
+
+    const card = compose(base, stack);
+
+    expectTypeOf(card).parameter(0).toMatchTypeOf<
+      | {
+          _tone?: "quiet" | "loud" | undefined;
+          gap?: 1 | 2 | undefined;
+        }
+      | undefined
+    >();
+  });
 });
 
 describe("cva — composes", () => {
@@ -472,14 +504,10 @@ describe("cva — internal variants", () => {
 
     expect(button()).toBe("button intent-primary size-sm");
 
-    // `_intent` is omitted from `VariantProps` (e.g. a wrapping React
-    // component's public props)...
     expectTypeOf<CVA.VariantProps<typeof button>>().toEqualTypeOf<{
       size?: "sm" | "lg" | undefined;
     }>();
 
-    // ...but the component itself still accepts it (no cast needed), so a
-    // wrapper can drive it internally.
     expect(button({ _intent: "secondary" })).toBe(
       "button intent-secondary size-sm",
     );
@@ -572,12 +600,9 @@ describe("cva — internal variants", () => {
 
     expect(card()).toBe("tone-quiet pad-sm");
 
-    // A composed internal variant is omitted from the composer's
-    // `VariantProps` too...
     expectTypeOf<CVA.VariantProps<typeof card>>().toEqualTypeOf<{
       pad?: "sm" | "lg" | undefined;
     }>();
-    // ...but the composer still accepts it directly.
     expect(card({ _tone: "loud" })).toBe("tone-loud pad-sm");
 
     expect(getSchema(card)).toStrictEqual({
@@ -596,9 +621,6 @@ describe("cva — internal variants", () => {
       defaultVariants: { _tone: "quiet" },
     });
 
-    // Redeclaring `_tone` locally is required to override its default from
-    // the composer — the same pre-existing rule that applies to any
-    // composed-only variant (public or internal).
     const card = cva({
       composes: base,
       variants: { _tone: { loud: "loud-local" } },

--- a/packages/cva/src/index.test.ts
+++ b/packages/cva/src/index.test.ts
@@ -450,6 +450,178 @@ describe("cva — composes", () => {
   });
 });
 
+describe("cva — internal variants", () => {
+  test("should hide a variant prefixed with `_` from props, but still apply it via defaults", () => {
+    const button = cva({
+      base: "button",
+      variants: {
+        _intent: {
+          primary: "intent-primary",
+          secondary: "intent-secondary",
+        },
+        size: {
+          sm: "size-sm",
+          lg: "size-lg",
+        },
+      },
+      defaultVariants: {
+        _intent: "primary",
+        size: "sm",
+      },
+    });
+
+    expect(button()).toBe("button intent-primary size-sm");
+
+    expectTypeOf<CVA.VariantProps<typeof button>>().toEqualTypeOf<{
+      size?: "sm" | "lg" | undefined;
+    }>();
+
+    // @ts-expect-error — `_intent` is internal and hidden from props
+    button({ _intent: "secondary" });
+  });
+
+  test("should still match compound variants against an internal variant", () => {
+    const button = cva({
+      base: "button",
+      variants: {
+        _intent: {
+          primary: "intent-primary",
+          secondary: "intent-secondary",
+        },
+        size: {
+          sm: "size-sm",
+          lg: "size-lg",
+        },
+      },
+      compoundVariants: [
+        {
+          _intent: "primary",
+          size: "lg",
+          class: "intent-primary-lg",
+        },
+        {
+          _intent: ["primary", "secondary"],
+          size: "sm",
+          class: "intent-any-sm",
+        },
+      ],
+      defaultVariants: {
+        _intent: "primary",
+        size: "sm",
+      },
+    });
+
+    expect(button({ size: "lg" })).toBe(
+      "button intent-primary size-lg intent-primary-lg",
+    );
+    expect(button()).toBe("button intent-primary size-sm intent-any-sm");
+  });
+
+  test("should still resolve an internal variant passed at runtime by an untyped caller", () => {
+    const button = cva({
+      base: "button",
+      variants: {
+        _intent: {
+          primary: "intent-primary",
+          secondary: "intent-secondary",
+        },
+      },
+      defaultVariants: { _intent: "primary" },
+    });
+
+    // Hiding is type-level only — an untyped/cast caller can still drive the
+    // internal variant directly, e.g. from a wrapper component.
+    expect((button as any)({ _intent: "secondary" })).toBe(
+      "button intent-secondary",
+    );
+  });
+
+  test("should omit an internal variant from getSchema, at runtime and in its type", () => {
+    const button = cva({
+      base: "button",
+      variants: {
+        _intent: {
+          primary: "intent-primary",
+          secondary: "intent-secondary",
+        },
+        size: {
+          sm: "size-sm",
+          lg: "size-lg",
+        },
+      },
+      defaultVariants: {
+        _intent: "primary",
+        size: "sm",
+      },
+    });
+
+    const schema = getSchema(button);
+
+    expect(schema).toStrictEqual({
+      size: { values: ["sm", "lg"], defaultValue: "sm" },
+    });
+    expectTypeOf(schema).toEqualTypeOf<{
+      size: { values: readonly ("sm" | "lg")[]; defaultValue: "sm" };
+    }>();
+  });
+
+  test("should hide a composed-only internal variant from the composer's props and schema", () => {
+    const base = cva({
+      variants: {
+        _tone: {
+          quiet: "tone-quiet",
+          loud: "tone-loud",
+        },
+      },
+      defaultVariants: { _tone: "quiet" },
+    });
+
+    const card = cva({
+      composes: base,
+      variants: {
+        pad: { sm: "pad-sm", lg: "pad-lg" },
+      },
+      defaultVariants: { pad: "sm" },
+    });
+
+    expect(card()).toBe("tone-quiet pad-sm");
+
+    expectTypeOf<CVA.VariantProps<typeof card>>().toEqualTypeOf<{
+      pad?: "sm" | "lg" | undefined;
+    }>();
+    // @ts-expect-error — `_tone` is internal, even when composed in
+    card({ _tone: "loud" });
+
+    expect(getSchema(card)).toStrictEqual({
+      pad: { values: ["sm", "lg"], defaultValue: "sm" },
+    });
+  });
+
+  test("should let a composer retune a composed-only internal default by redeclaring it locally", () => {
+    const base = cva({
+      variants: {
+        _tone: {
+          quiet: "tone-quiet",
+          loud: "tone-loud",
+        },
+      },
+      defaultVariants: { _tone: "quiet" },
+    });
+
+    // Redeclaring `_tone` locally is required to override its default from
+    // the composer — the same pre-existing rule that applies to any
+    // composed-only variant (public or internal).
+    const card = cva({
+      composes: base,
+      variants: { _tone: { loud: "loud-local" } },
+      defaultVariants: { _tone: "loud" },
+    });
+
+    expect(card()).toBe("tone-loud loud-local");
+    expect(getSchema(card)).toStrictEqual({});
+  });
+});
+
 describe("getSchema", () => {
   test("should return the schema for a component", () => {
     const buttonWithoutBaseWithDefaultsString = cva({

--- a/packages/cva/src/index.test.ts
+++ b/packages/cva/src/index.test.ts
@@ -451,7 +451,7 @@ describe("cva — composes", () => {
 });
 
 describe("cva — internal variants", () => {
-  test("should hide a variant prefixed with `_` from props, but still apply it via defaults", () => {
+  test("should omit a variant prefixed with `_` from VariantProps, but still accept it on the component", () => {
     const button = cva({
       base: "button",
       variants: {
@@ -472,12 +472,17 @@ describe("cva — internal variants", () => {
 
     expect(button()).toBe("button intent-primary size-sm");
 
+    // `_intent` is omitted from `VariantProps` (e.g. a wrapping React
+    // component's public props)...
     expectTypeOf<CVA.VariantProps<typeof button>>().toEqualTypeOf<{
       size?: "sm" | "lg" | undefined;
     }>();
 
-    // @ts-expect-error — `_intent` is internal and hidden from props
-    button({ _intent: "secondary" });
+    // ...but the component itself still accepts it (no cast needed), so a
+    // wrapper can drive it internally.
+    expect(button({ _intent: "secondary" })).toBe(
+      "button intent-secondary size-sm",
+    );
   });
 
   test("should still match compound variants against an internal variant", () => {
@@ -517,25 +522,6 @@ describe("cva — internal variants", () => {
     expect(button()).toBe("button intent-primary size-sm intent-any-sm");
   });
 
-  test("should still resolve an internal variant passed at runtime by an untyped caller", () => {
-    const button = cva({
-      base: "button",
-      variants: {
-        _intent: {
-          primary: "intent-primary",
-          secondary: "intent-secondary",
-        },
-      },
-      defaultVariants: { _intent: "primary" },
-    });
-
-    // Hiding is type-level only — an untyped/cast caller can still drive the
-    // internal variant directly, e.g. from a wrapper component.
-    expect((button as any)({ _intent: "secondary" })).toBe(
-      "button intent-secondary",
-    );
-  });
-
   test("should omit an internal variant from getSchema, at runtime and in its type", () => {
     const button = cva({
       base: "button",
@@ -565,7 +551,7 @@ describe("cva — internal variants", () => {
     }>();
   });
 
-  test("should hide a composed-only internal variant from the composer's props and schema", () => {
+  test("should omit a composed-only internal variant from the composer's VariantProps and schema", () => {
     const base = cva({
       variants: {
         _tone: {
@@ -586,11 +572,13 @@ describe("cva — internal variants", () => {
 
     expect(card()).toBe("tone-quiet pad-sm");
 
+    // A composed internal variant is omitted from the composer's
+    // `VariantProps` too...
     expectTypeOf<CVA.VariantProps<typeof card>>().toEqualTypeOf<{
       pad?: "sm" | "lg" | undefined;
     }>();
-    // @ts-expect-error — `_tone` is internal, even when composed in
-    card({ _tone: "loud" });
+    // ...but the composer still accepts it directly.
+    expect(card({ _tone: "loud" })).toBe("tone-loud pad-sm");
 
     expect(getSchema(card)).toStrictEqual({
       pad: { values: ["sm", "lg"], defaultValue: "sm" },

--- a/packages/cva/src/index.ts
+++ b/packages/cva/src/index.ts
@@ -105,7 +105,7 @@ type MergedDefaultVariants<T extends readonly unknown[]> = T extends readonly [
 
 export type VariantProps<Component extends (...args: any) => any> = Omit<
   OmitUndefined<Parameters<Component>[0]>,
-  "class" | "className"
+  "class" | "className" | InternalVariantKey
 >;
 
 /* compose
@@ -157,14 +157,10 @@ export type CVAVariantShape = Record<string, Record<string, ClassValue>>;
 type CVAVariantSchema<V extends CVAVariantShape> = {
   [Variant in keyof V]?: StringToBoolean<keyof V[Variant]> | undefined;
 };
-// A variant name prefixed with `_` is internal: settable via
-// `defaultVariants`/`compoundVariants`, but hidden from the public props API.
+// A variant name prefixed with `_` is internal: the component still accepts
+// it, but it's omitted from `VariantProps` (so it stays out of a wrapping
+// component's public props) and from `getSchema`.
 type InternalVariantKey = `_${string}`;
-type CVAVariantPropsSchema<V extends CVAVariantShape> = {
-  [Variant in keyof V as Variant extends InternalVariantKey
-    ? never
-    : Variant]?: StringToBoolean<keyof V[Variant]> | undefined;
-};
 type CVAClassProp =
   | {
       class?: ClassValue;
@@ -218,7 +214,7 @@ type CVAComponentConfig<
 export interface CVAComponent<Config, Variants> {
   (
     props?: Variants extends CVAVariantShape
-      ? CVAVariantPropsSchema<Variants> & CVAClassProp
+      ? CVAVariantSchema<Variants> & CVAClassProp
       : CVAClassProp,
   ): string;
   /** @internal */

--- a/packages/cva/src/index.ts
+++ b/packages/cva/src/index.ts
@@ -103,9 +103,14 @@ type MergedDefaultVariants<T extends readonly unknown[]> = T extends readonly [
   ? RightMerge<DefaultsOf<Head>, MergedDefaultVariants<Rest>>
   : {};
 
-export type VariantProps<Component extends (...args: any) => any> = Omit<
+type ComponentProps<Component extends (...args: any) => any> = Omit<
   OmitUndefined<Parameters<Component>[0]>,
-  "class" | "className" | InternalVariantKey
+  "class" | "className"
+>;
+
+export type VariantProps<Component extends (...args: any) => any> = Omit<
+  ComponentProps<Component>,
+  InternalVariantKey
 >;
 
 /* compose
@@ -126,7 +131,7 @@ export interface Compose {
     props?: (
       | UnionToIntersection<
           {
-            [K in keyof T]: VariantProps<T[K]>;
+            [K in keyof T]: ComponentProps<T[K]>;
           }[number]
         >
       | undefined
@@ -157,9 +162,6 @@ export type CVAVariantShape = Record<string, Record<string, ClassValue>>;
 type CVAVariantSchema<V extends CVAVariantShape> = {
   [Variant in keyof V]?: StringToBoolean<keyof V[Variant]> | undefined;
 };
-// A variant name prefixed with `_` is internal: the component still accepts
-// it, but it's omitted from `VariantProps` (so it stays out of a wrapping
-// component's public props) and from `getSchema`.
 type InternalVariantKey = `_${string}`;
 type CVAClassProp =
   | {
@@ -571,7 +573,6 @@ export const getSchema: GetSchema = (component) => {
 
   return Object.entries(component.config.variants).reduce(
     (acc, [key, value]) => {
-      // Mirrors the `InternalVariantKey` type-level filter above.
       if (key.startsWith("_")) return acc;
 
       const defaultValue = component.config.defaultVariants?.[key];

--- a/packages/cva/src/index.ts
+++ b/packages/cva/src/index.ts
@@ -157,6 +157,14 @@ export type CVAVariantShape = Record<string, Record<string, ClassValue>>;
 type CVAVariantSchema<V extends CVAVariantShape> = {
   [Variant in keyof V]?: StringToBoolean<keyof V[Variant]> | undefined;
 };
+// A variant name prefixed with `_` is internal: settable via
+// `defaultVariants`/`compoundVariants`, but hidden from the public props API.
+type InternalVariantKey = `_${string}`;
+type CVAVariantPropsSchema<V extends CVAVariantShape> = {
+  [Variant in keyof V as Variant extends InternalVariantKey
+    ? never
+    : Variant]?: StringToBoolean<keyof V[Variant]> | undefined;
+};
 type CVAClassProp =
   | {
       class?: ClassValue;
@@ -210,7 +218,7 @@ type CVAComponentConfig<
 export interface CVAComponent<Config, Variants> {
   (
     props?: Variants extends CVAVariantShape
-      ? CVAVariantSchema<Variants> & CVAClassProp
+      ? CVAVariantPropsSchema<Variants> & CVAClassProp
       : CVAClassProp,
   ): string;
   /** @internal */
@@ -534,10 +542,9 @@ export interface GetSchema {
         ? { config: CVAComponentConfig<Config, Variants> }
         : never),
   ): {
-    [Variant in keyof Variants]: Config extends CVAComponentConfig<
-      Config,
-      Variants
-    >
+    [Variant in keyof Variants as Variant extends InternalVariantKey
+      ? never
+      : Variant]: Config extends CVAComponentConfig<Config, Variants>
       ? Variant extends keyof Config["defaultVariants"]
         ? Config["defaultVariants"][Variant] extends undefined
           ? never
@@ -568,6 +575,9 @@ export const getSchema: GetSchema = (component) => {
 
   return Object.entries(component.config.variants).reduce(
     (acc, [key, value]) => {
+      // Mirrors the `InternalVariantKey` type-level filter above.
+      if (key.startsWith("_")) return acc;
+
       const defaultValue = component.config.defaultVariants?.[key];
       const hasDefaultValue = defaultValue !== undefined;
       const values = Object.keys(value).map((v) => {


### PR DESCRIPTION
Variant names starting with `_` are now internal: still declarable in `variants`, settable via `defaultVariants`, and matchable in `compoundVariants`, and the `cva` component itself still accepts them directly. What changes is the *derived* surface: internal variants are omitted from `VariantProps` and from `getSchema` (both its return type and its runtime object).

The motivating case is React consumption: you spread `VariantProps<typeof component>` into a wrapping component's public props, so an internal variant should stay off that public type while the component keeps accepting it internally (e.g. a `Button` that drives `_intent` from its own `active` prop).

### Behavior

- `VariantProps<typeof component>` omits `_`-prefixed keys (via `Omit<…, InternalVariantKey>`).
- The component's own call signature still accepts them (`CVAVariantSchema`, unchanged).
- `getSchema` omits them at the type level and in the runtime object.
- Composition: an internal variant merged in via `composes` is omitted from the composer's `VariantProps`/`getSchema` too, but still accepted by the composer. Changing a composed-only internal default requires redeclaring it locally, the same rule as any composed-only variant.
- Deprecated `compose()`: uses `ComponentProps` (not filtered `VariantProps`) so `_`-prefixed props stay accepted at the type level, matching runtime and the `composes` replacement.

### Breaking change

If a component already declared a `_`-prefixed variant and relied on `VariantProps` exposing it as a public prop, that variant now disappears from `VariantProps` and from `getSchema` results. The component still accepts it directly. Flagged in the What's New page.

Documented in `variants.mdx` (new "Internal variants" section with a React example), `typescript.mdx`, `api-reference.mdx`, `utilities.mdx`, and `whats-new.mdx`.

## Test plan

- [x] `pnpm --filter cva check:tsc`
- [x] `pnpm test` (269 tests)
- [x] `pnpm --filter cva build` (attw + publint)