### PR TITLE
Add maintenance-mode toolchain note for class-variance-authority

### DIFF
--- a/test/bench/scripts/compare.test.ts
+++ b/test/bench/scripts/compare.test.ts
@@ -256,6 +256,84 @@ describe("renderMarkdown", () => {
     expect(markdown).not.toContain("### How to read this");
   });
 
+  it("renders the maintenance-mode toolchain note for class-variance-authority", () => {
+    const result = validResult({
+      package: "class-variance-authority",
+      implementations: [
+        {
+          label: "local",
+          version: "0.7.1",
+          tasks: [
+            {
+              name: "Join class names",
+              hz: 100,
+              mean: 0.01,
+              rme: 0.5,
+              samples: 1000,
+            },
+          ],
+        },
+        {
+          label: "release",
+          version: "0.7.1",
+          tasks: [
+            {
+              name: "Join class names",
+              hz: 90,
+              mean: 0.011,
+              rme: 0.6,
+              samples: 900,
+            },
+          ],
+        },
+      ],
+    });
+    const markdown = renderMarkdown([
+      validateResult(result, "class-variance-authority"),
+    ]);
+
+    expect(markdown).toContain("> [!NOTE]");
+    expect(markdown).toContain("pre-`tsdown` toolchain");
+    // The note sits under the heading, above the table.
+    expect(markdown.indexOf("> [!NOTE]")).toBeLessThan(
+      markdown.indexOf("| Task |"),
+    );
+  });
+
+  it("omits the toolchain note when the release baseline is skipped", () => {
+    const result = validResult({
+      package: "class-variance-authority",
+      implementations: [
+        {
+          label: "local",
+          version: "0.7.1",
+          tasks: [
+            {
+              name: "Join class names",
+              hz: 100,
+              mean: 0.01,
+              rme: 0.5,
+              samples: 1000,
+            },
+          ],
+        },
+        { label: "release", version: "0.7.1", skipped: "not published on npm" },
+      ],
+    });
+    const markdown = renderMarkdown([
+      validateResult(result, "class-variance-authority"),
+    ]);
+
+    expect(markdown).not.toContain("> [!NOTE]");
+  });
+
+  it("does not render the toolchain note for cva", () => {
+    const validated = validateResult(validResult(), "cva");
+    const markdown = renderMarkdown([validated]);
+
+    expect(markdown).not.toContain("> [!NOTE]");
+  });
+
   it("renders runtime rows before static rows with display labels", () => {
     const result = validResult();
     const tasks = (result.implementations[0] as any).tasks;

--- a/test/bench/scripts/compare.test.ts
+++ b/test/bench/scripts/compare.test.ts
@@ -293,7 +293,7 @@ describe("renderMarkdown", () => {
     ]);
 
     expect(markdown).toContain("> [!NOTE]");
-    expect(markdown).toContain("pre-`tsdown` toolchain");
+    expect(markdown).toContain("predates the `tsdown` build migration");
     // The note sits under the heading, above the table.
     expect(markdown.indexOf("> [!NOTE]")).toBeLessThan(
       markdown.indexOf("| Task |"),

--- a/test/bench/scripts/compare.ts
+++ b/test/bench/scripts/compare.ts
@@ -325,6 +325,24 @@ function formatOps(hz: number, rme: number): string {
 
 const NOISE_THRESHOLD_PERCENT = 5;
 
+// Package-scoped callouts rendered under the heading, before the table.
+// `class-variance-authority` is in maintenance mode: its published `latest`
+// baseline still comes from the pre-`tsdown` (SWC) build, so part of any delta
+// against it measures that one-time build-toolchain/target change rather than
+// the source (which is unchanged since 0.7.1). See the toolchain caveat in
+// test/bench/scripts/harness.ts. Drop this entry once a `tsdown`-built
+// `class-variance-authority` release ships and re-baselines the comparison.
+const PACKAGE_NOTES: Record<string, string> = {
+  "class-variance-authority": [
+    "> [!NOTE]",
+    "> `class-variance-authority` is in maintenance mode. Its `latest` npm" +
+      " baseline was built with the pre-`tsdown` toolchain (a different" +
+      " down-leveling target), so part of any delta here reflects that" +
+      " one-time build change, not the source — treat it as indicative. The" +
+      " next published release re-baselines it.",
+  ].join("\n"),
+};
+
 const TASK_PRIORITY = [
   "Call component (default variants)",
   "Call component (with variants)",
@@ -390,6 +408,14 @@ function renderPackageSection(result: BenchmarkResult): string {
   const lines: string[] = [];
   lines.push(`### \`${escapeMarkdown(result.package)}\``);
   lines.push("");
+
+  // Only render the note when there's an actual baseline column to caveat —
+  // no rendered comparison, nothing to qualify.
+  const note = PACKAGE_NOTES[result.package];
+  if (note && baselines.some((b) => b.tasks && b.tasks.length > 0)) {
+    lines.push(note);
+    lines.push("");
+  }
 
   // Union across every implementation (local first), not just local — with
   // local missing, baseline columns must still render their rows instead

--- a/test/bench/scripts/compare.ts
+++ b/test/bench/scripts/compare.ts
@@ -335,11 +335,9 @@ const NOISE_THRESHOLD_PERCENT = 5;
 const PACKAGE_NOTES: Record<string, string> = {
   "class-variance-authority": [
     "> [!NOTE]",
-    "> `class-variance-authority` is in maintenance mode. Its `latest` npm" +
-      " baseline was built with the pre-`tsdown` toolchain (a different" +
-      " down-leveling target), so part of any delta here reflects that" +
-      " one-time build change, not the source — treat it as indicative. The" +
-      " next published release re-baselines it.",
+    "> `class-variance-authority` is in maintenance mode, and its latest" +
+      " `npm` baseline predates the `tsdown` build migration. Treat the" +
+      " deltas here as indicative.",
   ].join("\n"),
 };
 

--- a/test/bench/scripts/compare.ts
+++ b/test/bench/scripts/compare.ts
@@ -335,9 +335,7 @@ const NOISE_THRESHOLD_PERCENT = 5;
 const PACKAGE_NOTES: Record<string, string> = {
   "class-variance-authority": [
     "> [!NOTE]",
-    "> `class-variance-authority` is in maintenance mode, and its latest" +
-      " `npm` baseline predates the `tsdown` build migration. Treat the" +
-      " deltas here as indicative.",
+    "> `class-variance-authority` is in maintenance mode, and its latest `npm` baseline predates the `tsdown` build migration. Treat the deltas here as indicative.",
   ].join("\n"),
 };
 


### PR DESCRIPTION
### Description

Adds a package-scoped callout note for `class-variance-authority` to clarify that its published baseline predates the `tsdown` build migration. This note appears under the package heading and above the benchmark table, helping readers understand that performance deltas may reflect the one-time build-toolchain change rather than source changes.

The note is conditionally rendered only when:
- The package is `class-variance-authority`
- There is an actual baseline column with tasks to compare against (no note if the release baseline is skipped)

This addresses the maintenance-mode status of the stable `class-variance-authority` package, which will be dropped once a `tsdown`-built release ships and re-baselines the comparison.

### What is the purpose of this pull request?

- [x] Documentation update
- [ ] Bug fix
- [ ] New Feature
- [ ] Other

### Test Plan

Added three new test cases covering:
1. Rendering the maintenance-mode note for `class-variance-authority` with both local and release implementations
2. Omitting the note when the release baseline is skipped
3. Not rendering the note for other packages (e.g., `cva`)

All tests pass and validate the conditional rendering logic.

https://claude.ai/code/session_012hRdCGbMhkxTiWGmrvBhnV