### PR TITLE
build: extend dependency release delay to 72 hours

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,7 +4,7 @@ overrides:
   "mdast-util-directive>mdast-util-to-markdown": "2.1.2"
   "vite": "^8.1.0"
 
-minimumReleaseAge: 1440
+minimumReleaseAge: 4320
 
 packages:
   - "docs"


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Raises pnpm's minimum release age from 24 to 72 hours so newly published dependency versions have more time for supply-chain compromises to surface before resolution.

### Additional context

The existing dependency build allowlist remains unchanged. Validated with Prettier, pnpm's effective configuration, a frozen-lockfile install across all 16 workspace projects, and the repository's pre-commit hook.

---

### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md).
- [x] Follow the [Style Guide](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md#style-guide).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).