### PR TITLE
feat(cva): add Tailwind CSS base defaults

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,6 +160,8 @@ Agent-specific notes:
 
 Durable, hard-won lessons that don't fit a section above. See [Keeping this guide current](#keeping-this-guide-current-self-improving) for what belongs here and how to write it. Newest first; prune anything that's become wrong or obsolete.
 
+- A Tailwind custom variant can nest a lower layer inside `utilities` (`utilities.base`), rather than target Tailwind's top-level `base` layer. Treat `base:` as defaults: ordinary matching state, responsive, and dark utilities still win through layer precedence, and class order does not merge them.
+- For a package-owned CSS asset, use tsdown's `copy` plus `exports.customExports` with `isPublish` so workspace consumers resolve `src/` and packed consumers resolve `dist/`; use a CSS `sideEffects` glob to preserve stylesheet imports without disabling JavaScript tree shaking. Keep the strict attw checks for JavaScript entries and exclude only the CSS entry, then verify a normal import from the packed package instead of adding a fake TypeScript declaration.
 - Give deprecated value exports their own JSDoc declaration: destructuring a deprecated property into an export loses its marker in emitted declarations, even when the property and its interface are tagged. Verify editor metadata against the packed package.
 - Keep the base-only, non-composed `cx` call at fixed arity: spreading the shared empty composition array ahead of its arguments caused a repeatable throughput regression under the existing benchmark harness. Preserve the normal `cx` filtering and hook path when optimizing it.
 - Infer concatenator inputs with `readonly [...infer Inputs]`, then validate the complete callback against `string | CXInput<T>` so readonly rests and callback unions preserve the actual `cx` call contract.

--- a/docs/src/content/docs/beta/api-reference.mdx
+++ b/docs/src/content/docs/beta/api-reference.mdx
@@ -1,6 +1,6 @@
 ---
 title: API Reference
-description: API reference for cva, cva/config, and cva/utils.
+description: API reference for cva, cva/config, cva/utils, and cva/tailwindcss.
 ---
 
 ## `cva`
@@ -43,6 +43,17 @@ const className = cx(classes);
 ### Returns
 
 `string`
+
+## `cva/tailwindcss`
+
+Defines the `base:` variant for Tailwind CSS v4. Import it in your stylesheet after Tailwind CSS:
+
+```css
+@import "tailwindcss";
+@import "cva/tailwindcss";
+```
+
+See [CSS defaults with `base:`](/beta/getting-started/installation#css-defaults-with-base) for usage and cascade caveats.
 
 ## `cva/utils`
 
@@ -116,7 +127,7 @@ export const { cva, cx } = defineConfig(options);
      - It owns the class name grammar: `cva` passes composed outputs, `base`, matched variant and compound-variant values, and `class`/`className` through verbatim, one argument each.
      - Custom callbacks must accept empty calls, variadic inputs, and composed component strings.
      - The authoring surface adopts its parameter type: `twMerge` rejects object syntax, while `clsx` keeps the full clsx-flavored `ClassValue` grammar.
-     - See [Merging classes](/beta/getting-started/installation#merging-classes) for `cn` and `tailwind-merge` examples.
+     - See [Handling style conflicts](/beta/getting-started/installation#handling-style-conflicts) for CSS defaults, `cn`, and `tailwind-merge` examples.
    - `hooks`
      - `onComplete` and `"cx:done"` are deprecated. Each receives the concatenated string and returns a processed string. Use `cx` instead. When both hooks are set, `"cx:done"` takes precedence.
 

--- a/docs/src/content/docs/beta/examples/react/tailwindcss.mdx
+++ b/docs/src/content/docs/beta/examples/react/tailwindcss.mdx
@@ -21,9 +21,9 @@ These examples build a React `button` component with `cva` and Tailwind CSS. The
   file="src/components/nav/nav.tsx"
 />
 
-## Merging classes
+## Handling style conflicts
 
-Both examples resolve conflicting Tailwind CSS classes and conditional inputs. See [Merging classes](/beta/getting-started/installation#merging-classes) for the configurations.
+Both examples resolve conflicting Tailwind CSS classes and conditional inputs. See [Handling style conflicts](/beta/getting-started/installation#handling-style-conflicts) for CSS defaults and the configurations.
 
 ### cn
 

--- a/docs/src/content/docs/beta/getting-started/installation.mdx
+++ b/docs/src/content/docs/beta/getting-started/installation.mdx
@@ -1,6 +1,6 @@
 ---
 title: Installation
-description: Install cva@beta, configure Tailwind CSS IntelliSense, and merge conflicting utility classes.
+description: Install cva@beta, configure Tailwind CSS IntelliSense, and handle utility style conflicts.
 ---
 
 import { Tabs, TabItem, Steps } from "@astrojs/starlight/components";
@@ -123,11 +123,70 @@ You can enable autocompletion inside `cva` using the steps below:
   </TabItem>
 </Tabs>
 
-## Merging classes
+## Handling style conflicts
 
-By default, `cva` uses [`clsx`](https://github.com/lukeed/clsx) for conditional class joining. It does not resolve conflicting Tailwind CSS utilities.
+By default, `cva` uses [`clsx`](https://github.com/lukeed/clsx) for conditional class joining. It does not resolve conflicting Tailwind CSS utilities. Use CSS defaults for predictable component defaults, or configure a class-conflict library when you need more control.
 
-Both configurations accept conditional objects and arrays.
+### CSS defaults with `base:`
+
+The `base:` variant puts component defaults in a nested `base` layer inside Tailwind's utilities layer. It overrides normal browser defaults and Tailwind's `base` and `components` layers, while ordinary utilities take priority. This recipe requires Tailwind CSS v4.
+
+Import the variant after Tailwind CSS:
+
+```css
+@import "tailwindcss";
+@import "cva/tailwindcss";
+```
+
+<details>
+
+<summary>
+  Copy the <code>base:</code> definition instead
+</summary>
+
+```css
+@custom-variant base {
+  @layer base {
+    :where(&) {
+      @slot;
+    }
+  }
+}
+```
+
+</details>
+
+Put idle defaults behind `base:` and write ordinary state styles with Tailwind variants:
+
+```ts
+import { cva } from "cva";
+
+export const button = cva({
+  base: [
+    "base:bg-blue-600 base:px-4 base:py-2 base:text-white",
+    "hover:bg-blue-700",
+  ],
+});
+
+button({ className: "bg-violet-600" });
+```
+
+The idle `base:bg-blue-600` default yields to `bg-violet-600`, while the ordinary `hover:bg-blue-700` component style still applies on hover.
+
+This recipe was inspired by [Diego Haz's `base:` idea](https://x.com/diegohaz/status/1897776774206853269) and [a related `:where()` example](https://x.com/acd02/status/1897943176863756335).
+
+#### Cascade rules for `base:` defaults
+
+Keep these rules in mind:
+
+- `base:hover:`, `base:sm:`, and `base:dark:` defaults also live in the lower `base` layer, so an ordinary utility overrides them even while the state, breakpoint, or dark-mode condition matches.
+- HTML class order does not merge utilities or settle conflicts within one cascade tier. `base:` establishes defaults; it does not create last-class-wins merging.
+- `:where()` gives the class part of a plain `base:bg-*` selector zero specificity. Pseudo-classes and pseudo-elements add their own specificity. Put `base:` before a pseudo-element variant: `base:before:bg-*`, not `before:base:bg-*`.
+- Unlayered author styles override normal layered styles. With `!important`, layer order reverses, so important `base:` utilities override ordinary important utilities.
+
+Try `cn` or `tailwind-merge` when a component needs more robust class-conflict resolution than these cascade rules provide.
+
+Both external configurations accept conditional objects and arrays.
 
 ### cn
 

--- a/docs/src/content/docs/beta/getting-started/whats-new.mdx
+++ b/docs/src/content/docs/beta/getting-started/whats-new.mdx
@@ -15,7 +15,7 @@ TypeScript projects using `cva@beta` need TypeScript 6.0 or later. JavaScript us
 
 Roll your own `cva` via the new [`defineConfig` API in `cva/config`](/beta/api-reference#cvaconfig).
 
-Use `cva`/`cx` with `cn`, `tailwind-merge`, or your own concatenator via the [`cx` option](/beta/getting-started/installation#merging-classes).
+Use `cva`/`cx` with `cn`, `tailwind-merge`, or your own concatenator via the [`cx` option](/beta/getting-started/installation#handling-style-conflicts).
 
 ### 2. `composes`
 
@@ -38,6 +38,10 @@ If a component already declared a variant with a leading underscore (`_state`, `
 ### 5. Bring your own concatenator with `cva/config`
 
 The `cva` package is a preset over the core: it wires `cva` and `cx` to `clsx`, like `class-variance-authority`. Use `cva/config` with a required `cx` option to configure `clsx/lite`, `cn`, `tailwind-merge`, or your own concatenator.
+
+### 6. CSS defaults with `cva/tailwindcss`
+
+Import `cva/tailwindcss` to use [`base:` defaults](/beta/getting-started/installation#css-defaults-with-base) with Tailwind CSS v4. Ordinary utilities override these defaults through CSS, with no runtime class merging.
 
 ## Deprecations
 

--- a/docs/src/content/docs/getting-started/installation.mdx
+++ b/docs/src/content/docs/getting-started/installation.mdx
@@ -144,11 +144,50 @@ You can enable autocompletion inside `cva` using the steps below:
 
 ### Handling style conflicts
 
-Although `cva`'s API is designed to help you avoid styling conflicts, there's still a small margin of error.
+By default, `cva` joins conditional class names but does not resolve conflicting Tailwind CSS utilities. Use CSS defaults to give consumers a predictable override path, or merge classes when a component needs more control.
 
-If you're keen to lift that burden altogether, check out the wonderful [`tailwind-merge`](https://github.com/dcastil/tailwind-merge) package.
+#### CSS defaults with `base:`
 
-For bulletproof components, wrap your `cva` component with `twMerge`.
+This copyable Tailwind CSS v4 recipe puts component defaults in a lower nested layer. Add it after Tailwind's import:
+
+```css
+@import "tailwindcss";
+
+@custom-variant base {
+  @layer base {
+    :where(&) {
+      @slot;
+    }
+  }
+}
+```
+
+Use `cva` to apply idle defaults and ordinary state styles:
+
+```ts
+import { cva } from "class-variance-authority";
+
+const buttonVariants = cva(
+  "base:bg-blue-600 base:px-4 base:py-2 base:text-white hover:bg-blue-700",
+);
+
+buttonVariants({ className: "bg-violet-600" });
+```
+
+The idle `base:` defaults yield to ordinary utilities. Keep these cascade rules in mind:
+
+- `base:hover:`, `base:sm:`, and `base:dark:` defaults yield to ordinary utilities even while the state, breakpoint, or dark-mode condition matches.
+- HTML class order does not merge utilities or settle conflicts within one cascade tier. `base:` establishes defaults; it does not create last-class-wins merging.
+- `:where()` gives the class part of a plain `base:bg-*` selector zero specificity. Pseudo-classes and pseudo-elements add their own specificity. Put `base:` before a pseudo-element variant: `base:before:bg-*`, not `before:base:bg-*`.
+- Unlayered author styles override normal layered styles. With `!important`, layer order reverses, so important `base:` utilities override ordinary important utilities.
+
+This recipe was inspired by [Diego Haz's `base:` idea](https://x.com/diegohaz/status/1897776774206853269) and [a related `:where()` example](https://x.com/acd02/status/1897943176863756335).
+
+Try an external library such as `tailwind-merge` when a component needs more robust class-conflict resolution than these cascade rules provide.
+
+#### tailwind-merge
+
+Use [`tailwind-merge`](https://github.com/dcastil/tailwind-merge) to resolve Tailwind CSS conflicts before you render a component.
 
 <details>
 

--- a/packages/cva/package.json
+++ b/packages/cva/package.json
@@ -19,12 +19,15 @@
   "repository": "https://github.com/joe-bell/cva.git",
   "license": "Apache-2.0",
   "author": "Joe Bell (https://joebell.studio)",
-  "sideEffects": false,
+  "sideEffects": [
+    "**/*.css"
+  ],
   "exports": {
     ".": "./src/index.ts",
     "./config": "./src/config.ts",
     "./utils": "./src/utils.ts",
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    "./tailwindcss": "./src/tailwindcss.css"
   },
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
@@ -55,6 +58,8 @@
     "react-dom": "19.2.6",
     "size-limit": "^12.1.0",
     "tailwind-merge": "3.6.0",
+    "tailwindcss": "^4.3.0",
+    "tailwindcss-v4": "npm:tailwindcss@4.0.0",
     "tsdown": "0.22.4",
     "typescript": "6.0.3",
     "unplugin-unused": "0.5.7"
@@ -81,7 +86,8 @@
         "import": "./dist/utils.mjs",
         "require": "./dist/utils.cjs"
       },
-      "./package.json": "./package.json"
+      "./package.json": "./package.json",
+      "./tailwindcss": "./dist/tailwindcss.css"
     },
     "main": "dist/index.cjs",
     "module": "dist/index.mjs",

--- a/packages/cva/src/tailwindcss.css
+++ b/packages/cva/src/tailwindcss.css
@@ -1,0 +1,7 @@
+@custom-variant base {
+  @layer base {
+    :where(&) {
+      @slot;
+    }
+  }
+}

--- a/packages/cva/src/tailwindcss.test.ts
+++ b/packages/cva/src/tailwindcss.test.ts
@@ -1,0 +1,89 @@
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, resolve } from "node:path";
+import { compile as compileCurrent } from "tailwindcss";
+import { compile as compileMinimum } from "tailwindcss-v4";
+
+const css = readFileSync(resolve(__dirname, "tailwindcss.css"), "utf8");
+const packageJson = JSON.parse(
+  readFileSync(resolve(__dirname, "../package.json"), "utf8"),
+);
+const require = createRequire(__filename);
+
+function loadTailwindStylesheet(packageName: string) {
+  const packageRoot = dirname(require.resolve(`${packageName}/package.json`));
+
+  return async (id: string) => {
+    const stylesheet = resolve(
+      packageRoot,
+      id === "tailwindcss" ? "index.css" : id.replace(/^tailwindcss\//, ""),
+    );
+
+    return {
+      base: dirname(stylesheet),
+      content: readFileSync(stylesheet, "utf8"),
+      path: stylesheet,
+    };
+  };
+}
+
+describe("cva/tailwindcss", () => {
+  test.each([
+    [
+      `Tailwind CSS ${require("tailwindcss-v4/package.json").version}`,
+      "tailwindcss-v4",
+      compileMinimum,
+      [
+        /\.base\\:bg-red-500\s*\{\s*@layer base\s*\{\s*:where\(&\)\s*\{/,
+        /\.base\\:hover\\:bg-red-500\s*\{\s*@layer base\s*\{\s*:where\(&\)\s*\{\s*&:hover\s*\{/,
+        /\.base\\:before\\:bg-red-500\s*\{\s*@layer base\s*\{\s*:where\(&\)\s*\{\s*&::before\s*\{/,
+      ],
+    ],
+    [
+      `Tailwind CSS ${require("tailwindcss/package.json").version}`,
+      "tailwindcss",
+      compileCurrent,
+      [
+        /@layer utilities\s*\{\s*@layer base\s*\{\s*:where\(.base\\:bg-red-500\)\s*\{/,
+        /:where\(.base\\:hover\\:bg-red-500\):hover\s*\{/,
+        /:where\(.base\\:before\\:bg-red-500\)::before\s*\{/,
+      ],
+    ],
+  ])(
+    "compiles nested base utilities with %s",
+    async (_, packageName, compile, expectations) => {
+      const compiler = await compile(`@import "tailwindcss";\n${css}`, {
+        loadStylesheet: loadTailwindStylesheet(packageName),
+      });
+      const output = compiler.build([
+        "base:bg-red-500",
+        "base:hover:bg-red-500",
+        "base:before:bg-red-500",
+      ]);
+
+      expect(output).toMatch(/@layer utilities\s*\{/);
+
+      for (const expectation of expectations) {
+        expect(output).toMatch(expectation);
+      }
+    },
+  );
+
+  test("exports the stylesheet without a runtime Tailwind dependency", () => {
+    expect(packageJson).toMatchObject({
+      sideEffects: ["**/*.css"],
+      exports: {
+        "./tailwindcss": "./src/tailwindcss.css",
+      },
+      publishConfig: {
+        exports: {
+          "./tailwindcss": "./dist/tailwindcss.css",
+        },
+      },
+    });
+    expect(packageJson.dependencies ?? {}).not.toHaveProperty("tailwindcss");
+    expect(packageJson.peerDependencies ?? {}).not.toHaveProperty(
+      "tailwindcss",
+    );
+  });
+});

--- a/packages/cva/tsdown.config.mts
+++ b/packages/cva/tsdown.config.mts
@@ -5,4 +5,21 @@ export default defineConfig({
   ...base,
   // Hand-maintained node10 `typesVersions` fallbacks cover these subpaths.
   entry: ["src/index.ts", "src/config.ts", "src/utils.ts"],
+  copy: [{ from: "src/tailwindcss.css", to: "dist" }],
+  exports: {
+    devExports: true,
+    customExports(exports, { isPublish }) {
+      return {
+        ...exports,
+        "./tailwindcss": isPublish
+          ? "./dist/tailwindcss.css"
+          : "./src/tailwindcss.css",
+      };
+    },
+  },
+  // Tailwind's stylesheet resolver consumes this CSS-only entry.
+  attw: {
+    ...base.attw,
+    excludeEntrypoints: ["./tailwindcss"],
+  },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -583,6 +583,12 @@ importers:
       tailwind-merge:
         specifier: 3.6.0
         version: 3.6.0
+      tailwindcss:
+        specifier: ^4.3.0
+        version: 4.3.3
+      tailwindcss-v4:
+        specifier: npm:tailwindcss@4.0.0
+        version: tailwindcss@4.0.0
       tsdown:
         specifier: 0.22.4
         version: 0.22.4(@arethetypeswrong/core@0.18.2)(publint@0.3.21)(typescript@6.0.3)(unplugin-unused@0.5.7(esbuild@0.28.1)(rolldown@1.1.5)(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.8.4)))(vue-tsc@3.2.8(typescript@6.0.3))
@@ -4185,11 +4191,17 @@ packages:
   tailwind-merge@3.6.0:
     resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==}
 
+  tailwindcss@4.0.0:
+    resolution: {integrity: sha512-ULRPI3A+e39T7pSaf1xoi58AqqJxVCLg8F/uM5A3FadUbnyDTgltVnXJvdkTjwCOGA6NazqHVcwPJC5h2vRYVQ==}
+
   tailwindcss@4.2.4:
     resolution: {integrity: sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA==}
 
   tailwindcss@4.3.0:
     resolution: {integrity: sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==}
+
+  tailwindcss@4.3.3:
+    resolution: {integrity: sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==}
 
   tapable@2.3.3:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
@@ -8846,9 +8858,13 @@ snapshots:
 
   tailwind-merge@3.6.0: {}
 
+  tailwindcss@4.0.0: {}
+
   tailwindcss@4.2.4: {}
 
   tailwindcss@4.3.0: {}
+
+  tailwindcss@4.3.3: {}
 
   tapable@2.3.3: {}
 


### PR DESCRIPTION
### Description

Adds a CSS-only `cva/tailwindcss` import for Tailwind CSS v4. Component defaults such as `base:bg-blue-600` yield to a consumer's `bg-violet-600` through the CSS cascade, without runtime class merging.

The installation guides describe `cva/tailwindcss` as custom Tailwind CSS variants, introduce `base:` before the library approaches, credit Diego Haz and the related `:where()` example, and list its limitations (conditional defaults, class order, pseudo-element variant order, and `!important`). Readers who would rather not think about the cascade are pointed at `cn` and `tailwind-merge`. Stable users get a copyable CSS recipe; the package export belongs to `cva@beta`.

Addresses [JB-389](https://linear.app/big-attic/issue/JB-389), [JB-409](https://linear.app/big-attic/issue/JB-409), and [JB-361](https://linear.app/big-attic/issue/JB-361).

### Additional context

The stylesheet ships through tsdown's copy and generated-export configuration, with CSS side-effect metadata and no new runtime dependency. The CSS-only entry is excluded from TypeScript resolution analysis; existing JavaScript entries retain strict attw checks. The packed-consumer verifier asserts that `cva/tailwindcss` resolves to `dist/tailwindcss.css` from the extracted tarball.

Validation: 381 tests with 100% coverage; package and docs builds; all example builds; bundle limits; type checks; syncpack and skills lint. Real Tailwind compilation covers 4.0.0 and 4.3.3. A packed-package import passed 33 Chrome assertions across raw, optimized, and minified CSS; minimum-version output passed 10 browser assertions.

Implemented with GPT-5.6 Terra (max), followed by two orchestrator review rounds and an independent Fable 5.1 review. Fable found no blocking issues and independently passed 14 browser assertions; final documentation and test-label polish was applied afterward. Browser checks use temporary harnesses; committed tests cover generated CSS.

---

### What is the purpose of this pull request?

- [ ] Bug fix
- [x] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md).
- [x] Follow the [Style Guide](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md#style-guide).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/4340e91d-b1e9-4d46-8415-74fe34f21d66)

