### PR TITLE
docs: group Tailwind classes across examples and beta docs

### DIFF
--- a/docs/src/components/tutorial-list.astro
+++ b/docs/src/components/tutorial-list.astro
@@ -16,56 +16,38 @@ const { format } = Astro.props;
 
 {
   format === "YouTube" ? (
-    <ul class:list={["grid", "gap-4", "list-none", "pl-0", "sm:grid-cols-2"]}>
+    <ul class:list={["grid list-none gap-4 pl-0", "sm:grid-cols-2"]}>
       {tutorials
         .map(({ data: tutorial }) => {
           if (tutorial.format === "YouTube")
             return (
-              <li class:list={"mt-0!"}>
+              <li class="mt-0!">
                 <article
                   class:list={[
-                    "relative",
-                    "mb-0!",
-                    "flex",
-                    "flex-col",
-                    "h-full",
-                    "rounded-lg",
-                    ["bg-gray-100", "dark:bg-gray-800"],
-                    "border",
-                    ["border-gray-200", "dark:border-gray-700"],
-                    "overflow-hidden",
-                    ["hover:border-gray-300", "dark:hover:border-gray-600"],
-                    "transition-colors",
+                    "relative mb-0! flex h-full flex-col overflow-hidden",
+                    "rounded-lg border border-gray-200 bg-gray-100 transition-colors",
+                    "hover:border-gray-300",
+                    "dark:border-gray-700 dark:bg-gray-800",
+                    "dark:hover:border-gray-600",
                   ]}
                 >
                   <img
                     src={`https://img.youtube.com/vi/${tutorial.youtubeId}/sddefault.jpg`}
                     class:list={[
+                      "aspect-video w-full object-cover",
                       "bg-gray-200",
-                      "aspect-video",
-                      "object-cover",
-                      "w-full",
                     ]}
                   />
 
-                  <div
-                    class:list={["flex", "flex-col", "gap-1", "p-3", "mt-0!"]}
-                  >
+                  <div class="mt-0! flex flex-col gap-1 p-3">
                     <h1 class="mt-0! text-base! leading-tight!">
                       <a
                         href={`https://www.youtube.com/watch?v=${tutorial.youtubeId}`}
                         class:list={[
-                          "no-underline",
-                          "static",
-                          "before:content-['']",
-                          "cursor-pointer",
-                          "before:cursor-pointer",
-                          "before:block",
-                          "before:absolute",
-                          "before:top-0",
-                          "before:left-0",
-                          "before:w-full",
-                          "before:h-full",
+                          "static cursor-pointer no-underline",
+                          "before:absolute before:top-0 before:left-0 before:block",
+                          "before:h-full before:w-full",
+                          "before:cursor-pointer before:content-['']",
                         ]}
                       >
                         {tutorial.title}
@@ -73,15 +55,16 @@ const { format } = Astro.props;
                     </h1>
                     <p
                       class:list={[
-                        "mt-0! inline-flex flex-wrap items-center gap-x-1.5 gap-y-0.5 text-xs!",
-                        ["text-gray-800", "dark:text-gray-300"],
+                        "mt-0! inline-flex flex-wrap items-center gap-x-1.5 gap-y-0.5",
+                        "text-xs! text-gray-800",
+                        "dark:text-gray-300",
                       ]}
                     >
                       <span>{tutorial.author}</span>
                       <span
                         class:list={[
-                          "text-[0.75em]!",
-                          ["text-gray-600", "dark:text-gray-400"],
+                          "text-[0.75em]! text-gray-600",
+                          "dark:text-gray-400",
                         ]}
                       >
                         •

--- a/docs/src/content/docs/beta/examples/11ty.mdx
+++ b/docs/src/content/docs/beta/examples/11ty.mdx
@@ -17,21 +17,17 @@ const button = cva({
   variants: {
     intent: {
       primary: [
-        "bg-blue-500",
-        "text-white",
-        "border-transparent",
+        "bg-blue-500 text-white border-transparent",
         "hover:bg-blue-600",
       ],
       secondary: [
-        "bg-white",
-        "text-gray-800",
-        "border-gray-400",
+        "bg-white text-gray-800 border-gray-400",
         "hover:bg-gray-100",
       ],
     },
     size: {
-      small: ["text-sm", "py-1", "px-2"],
-      medium: ["text-base", "py-2", "px-4"],
+      small: "py-1 px-2 text-sm",
+      medium: "py-2 px-4 text-base",
     },
   },
   compoundVariants: [{ intent: "primary", size: "medium", class: "uppercase" }],

--- a/docs/src/content/docs/beta/getting-started/variants.mdx
+++ b/docs/src/content/docs/beta/getting-started/variants.mdx
@@ -22,15 +22,13 @@ import { cva } from "cva";
 const button = cva({
   base: "rounded border font-semibold",
   // **or**
-  // base: ["font-semibold", "border", "rounded"],
+  // base: ["font-semibold", "border rounded"],
   variants: {
     intent: {
       primary: "border-transparent bg-blue-500 text-white hover:bg-blue-600",
       // **or**
       // primary: [
-      //   "bg-blue-500",
-      //   "text-white",
-      //   "border-transparent",
+      //   "bg-blue-500 text-white border-transparent",
       //   "hover:bg-blue-600",
       // ],
       secondary: "border-gray-400 bg-white text-gray-800 hover:bg-gray-100",

--- a/examples/beta/astro-with-tailwindcss/src/components/button.astro
+++ b/examples/beta/astro-with-tailwindcss/src/components/button.astro
@@ -6,16 +6,16 @@ const button = cva({
   base: "button",
   variants: {
     intent: {
-      primary: ["bg-blue-500", "text-white", "border-transparent"],
-      secondary: ["bg-white", "text-gray-800", "border-gray-400"],
+      primary: "bg-blue-500 text-white border-transparent",
+      secondary: "bg-white text-gray-800 border-gray-400",
     },
     size: {
-      small: ["text-sm", "py-1", "px-2"],
-      medium: ["text-base", "py-2", "px-4"],
+      small: "py-1 px-2 text-sm",
+      medium: "py-2 px-4 text-base",
     },
     disabled: {
       false: null,
-      true: ["opacity-50", "cursor-not-allowed"],
+      true: "opacity-50 cursor-not-allowed",
     },
   },
   compoundVariants: [

--- a/examples/beta/astro-with-tailwindcss/src/pages/index.astro
+++ b/examples/beta/astro-with-tailwindcss/src/pages/index.astro
@@ -14,12 +14,10 @@ const isDisabled = [false, true] as const;
     <meta name="generator" content={Astro.generator} />
     <title>cva: Astro with Tailwind CSS</title>
   </head>
-  <body class:list={["grid", "h-full w-full", "p-6"]}>
+  <body class="grid h-full w-full p-6">
     <table
       class:list={[
-        "relative",
-        "h-max w-max",
-        "self-center justify-self-center",
+        "relative h-max w-max self-center justify-self-center",
         "[&_:where(th,td)]:p-2",
       ]}
     >

--- a/examples/beta/react-with-cn/src/app.tsx
+++ b/examples/beta/react-with-cn/src/app.tsx
@@ -10,9 +10,7 @@ function App() {
   return (
     <table
       className={cn(
-        "relative",
-        "h-max w-max",
-        "self-center justify-self-center",
+        "relative h-max w-max self-center justify-self-center",
         "[&_:where(th,td)]:p-2",
       )}
     >

--- a/examples/beta/react-with-cn/src/components/button/button.tsx
+++ b/examples/beta/react-with-cn/src/components/button/button.tsx
@@ -7,16 +7,16 @@ const button = cva({
   base: "font-semibold border rounded bg-gray-200 text-gray-800",
   variants: {
     intent: {
-      primary: ["bg-blue-500", "text-white", "border-transparent"],
-      secondary: ["bg-white", "border-gray-400"],
+      primary: "bg-blue-500 text-white border-transparent",
+      secondary: "bg-white border-gray-400",
     },
     size: {
-      small: ["text-sm", "py-1", "px-2"],
-      medium: ["text-base", "py-2", "px-4"],
+      small: "py-1 px-2 text-sm",
+      medium: "py-2 px-4 text-base",
     },
     disabled: {
       false: null,
-      true: ["opacity-50", "cursor-not-allowed"],
+      true: "opacity-50 cursor-not-allowed",
     },
   },
   compoundVariants: [

--- a/examples/beta/react-with-tailwind-merge/src/app.tsx
+++ b/examples/beta/react-with-tailwind-merge/src/app.tsx
@@ -10,9 +10,7 @@ function App() {
   return (
     <table
       className={cn(
-        "relative",
-        "h-max w-max",
-        "self-center justify-self-center",
+        "relative h-max w-max self-center justify-self-center",
         "[&_:where(th,td)]:p-2",
       )}
     >

--- a/examples/beta/react-with-tailwind-merge/src/components/button/button.tsx
+++ b/examples/beta/react-with-tailwind-merge/src/components/button/button.tsx
@@ -7,16 +7,16 @@ const button = cva({
   base: "font-semibold border rounded bg-gray-200 text-gray-800",
   variants: {
     intent: {
-      primary: ["bg-blue-500", "text-white", "border-transparent"],
-      secondary: ["bg-white", "border-gray-400"],
+      primary: "bg-blue-500 text-white border-transparent",
+      secondary: "bg-white border-gray-400",
     },
     size: {
-      small: ["text-sm", "py-1", "px-2"],
-      medium: ["text-base", "py-2", "px-4"],
+      small: "py-1 px-2 text-sm",
+      medium: "py-2 px-4 text-base",
     },
     disabled: {
       false: null,
-      true: ["opacity-50", "cursor-not-allowed"],
+      true: "opacity-50 cursor-not-allowed",
     },
   },
   compoundVariants: [

--- a/examples/beta/react-with-tailwindcss-compound/src/app.tsx
+++ b/examples/beta/react-with-tailwindcss-compound/src/app.tsx
@@ -39,9 +39,7 @@ function App() {
   return (
     <table
       className={cx(
-        "relative",
-        "h-max w-max",
-        "self-center justify-self-center",
+        "relative h-max w-max self-center justify-self-center",
         "[&_:where(th,td)]:p-4",
       )}
     >

--- a/examples/beta/react-with-tailwindcss-compound/src/components/nav/nav.tsx
+++ b/examples/beta/react-with-tailwindcss-compound/src/components/nav/nav.tsx
@@ -8,9 +8,7 @@ export const root = cva({
   base: [
     "[--nav-item-py-offset:calc(var(--nav-item-py)*0.5*-1)]",
     "flex flex-col",
-    "rounded-(--nav-radius)",
-    "border border-zinc-200",
-    "shadow-sm",
+    "rounded-(--nav-radius) border border-zinc-200 shadow-sm",
   ],
   variants: {
     density: {
@@ -63,11 +61,12 @@ export const Item: React.FC<ItemProps> = ({ className, ...props }) => (
 
 export const link = cva({
   base: [
-    "relative flex bg-transparent font-light text-sm text-zinc-800",
-    "px-(--nav-item-px) py-(--nav-item-py)",
+    "relative flex px-(--nav-item-px) py-(--nav-item-py)",
+    "font-light text-sm",
+    "bg-transparent text-zinc-800",
     "hover:bg-zinc-50 hover:text-zinc-900 hover:z-20",
     "focus-visible:bg-white focus-visible:z-30 focus-visible:outline-none",
-    " focus-visible:ring-zinc-600 focus-visible:ring-2",
+    "focus-visible:ring-zinc-600 focus-visible:ring-2",
     "group-first/nav-item:rounded-t-(--nav-radius)",
     "group-last/nav-item:rounded-b-(--nav-radius)",
   ],

--- a/examples/beta/react-with-tailwindcss/src/app.tsx
+++ b/examples/beta/react-with-tailwindcss/src/app.tsx
@@ -10,9 +10,7 @@ function App() {
   return (
     <table
       className={cx(
-        "relative",
-        "h-max w-max",
-        "self-center justify-self-center",
+        "relative h-max w-max self-center justify-self-center",
         "[&_:where(th,td)]:p-2",
       )}
     >

--- a/examples/beta/react-with-tailwindcss/src/components/button/button.tsx
+++ b/examples/beta/react-with-tailwindcss/src/components/button/button.tsx
@@ -5,16 +5,16 @@ const button = cva({
   base: "button",
   variants: {
     intent: {
-      primary: ["bg-blue-500", "text-white", "border-transparent"],
-      secondary: ["bg-white", "text-gray-800", "border-gray-400"],
+      primary: "bg-blue-500 text-white border-transparent",
+      secondary: "bg-white text-gray-800 border-gray-400",
     },
     size: {
-      small: ["text-sm", "py-1", "px-2"],
-      medium: ["text-base", "py-2", "px-4"],
+      small: "py-1 px-2 text-sm",
+      medium: "py-2 px-4 text-base",
     },
     disabled: {
       false: null,
-      true: ["opacity-50", "cursor-not-allowed"],
+      true: "opacity-50 cursor-not-allowed",
     },
   },
   compoundVariants: [

--- a/examples/latest/astro-with-tailwindcss/src/components/button.astro
+++ b/examples/latest/astro-with-tailwindcss/src/components/button.astro
@@ -5,16 +5,16 @@ import { cva, type VariantProps } from "class-variance-authority";
 const button = cva("button", {
   variants: {
     intent: {
-      primary: ["bg-blue-500", "text-white", "border-transparent"],
-      secondary: ["bg-white", "text-gray-800", "border-gray-400"],
+      primary: "bg-blue-500 text-white border-transparent",
+      secondary: "bg-white text-gray-800 border-gray-400",
     },
     size: {
-      small: ["text-sm", "py-1", "px-2"],
-      medium: ["text-base", "py-2", "px-4"],
+      small: "py-1 px-2 text-sm",
+      medium: "py-2 px-4 text-base",
     },
     disabled: {
       false: null,
-      true: ["opacity-50", "cursor-not-allowed"],
+      true: "opacity-50 cursor-not-allowed",
     },
   },
   compoundVariants: [

--- a/examples/latest/astro-with-tailwindcss/src/pages/index.astro
+++ b/examples/latest/astro-with-tailwindcss/src/pages/index.astro
@@ -14,12 +14,10 @@ const isDisabled = [false, true] as const;
     <meta name="generator" content={Astro.generator} />
     <title>cva: Astro with Tailwind CSS</title>
   </head>
-  <body class:list={["grid", "h-full w-full", "p-6"]}>
+  <body class="grid h-full w-full p-6">
     <table
       class:list={[
-        "relative",
-        "h-max w-max",
-        "self-center justify-self-center",
+        "relative h-max w-max self-center justify-self-center",
         "[&_:where(th,td)]:p-2",
       ]}
     >

--- a/examples/latest/react-with-tailwindcss/src/app.tsx
+++ b/examples/latest/react-with-tailwindcss/src/app.tsx
@@ -9,9 +9,7 @@ function App() {
   return (
     <table
       className={cx(
-        "relative",
-        "h-max w-max",
-        "self-center justify-self-center",
+        "relative h-max w-max self-center justify-self-center",
         "[&_:where(th,td)]:p-2",
       )}
     >

--- a/examples/latest/react-with-tailwindcss/src/components/button/button.tsx
+++ b/examples/latest/react-with-tailwindcss/src/components/button/button.tsx
@@ -4,16 +4,16 @@ import { cva, type VariantProps } from "class-variance-authority";
 const button = cva("button", {
   variants: {
     intent: {
-      primary: ["bg-blue-500", "text-white", "border-transparent"],
-      secondary: ["bg-white", "text-gray-800", "border-gray-400"],
+      primary: "bg-blue-500 text-white border-transparent",
+      secondary: "bg-white text-gray-800 border-gray-400",
     },
     size: {
-      small: ["text-sm", "py-1", "px-2"],
-      medium: ["text-base", "py-2", "px-4"],
+      small: "py-1 px-2 text-sm",
+      medium: "py-2 px-4 text-base",
     },
     disabled: {
       false: null,
-      true: ["opacity-50", "cursor-not-allowed"],
+      true: "opacity-50 cursor-not-allowed",
     },
   },
   compoundVariants: [


### PR DESCRIPTION
### Description

Group related Tailwind utilities into readable strings across the beta and latest examples, beta documentation snippets, and shared tutorial UI. Short button variants use single strings; longer table and navigation lists keep separate groups for structure, typography, appearance, and states.

### Additional context

Class tokens, conditions, and consumer override precedence are preserved. Legacy documentation content is untouched. Test and benchmark fixture shapes remain intact because they exercise array, nesting, and argument-order behavior. Validation includes builds of all seven affected examples and 324 before/after button variant and override comparisons, a full docs build with type checks, verified beta documentation output comments, plus the repository build, bundle-size, type, formatting, skills, dependency-consistency, and coverage checks. Security review found no high-confidence vulnerabilities.

---

### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md).
- [x] Follow the [Style Guide](https://github.com/joe-bell/cva/blob/main/CONTRIBUTING.md#style-guide).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
